### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include pickle5 *.c *.h
+
+include LICENSE


### PR DESCRIPTION
Fixes https://github.com/pitrou/pickle5-backport/issues/2

Make sure the license file is included in PyPI sdists.