### PR TITLE
'reducer_override' support 

### DIFF
--- a/patch
+++ b/patch
@@ -1,5 +1,5 @@
---- ../default/Include/picklebufobject.h	2019-04-24 21:34:21.441820415 +0200
-+++ pickle5/picklebufobject.h	2019-04-25 01:10:27.178803585 +0200
+--- ../cpython-3.8.0rc1/Include/picklebufobject.h	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/picklebufobject.h	2019-10-10 21:27:34.000000000 -0700
 @@ -10,18 +10,18 @@
  
  #ifndef Py_LIMITED_API
@@ -23,8 +23,8 @@
  
  #endif /* !Py_LIMITED_API */
  
---- ../default/Objects/picklebufobject.c	2019-04-24 23:22:09.714808011 +0200
-+++ pickle5/picklebufobject.c	2019-04-25 01:10:27.178803585 +0200
+--- ../cpython-3.8.0rc1/Objects/picklebufobject.c	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/picklebufobject.c	2019-10-10 21:29:15.000000000 -0700
 @@ -4,6 +4,8 @@
  #include "Python.h"
  #include <stddef.h>
@@ -34,8 +34,8 @@
  typedef struct {
      PyObject_HEAD
      /* The view exported by the original object */
---- ../default/Modules/_pickle.c	2019-04-24 23:56:10.787938850 +0200
-+++ pickle5/_pickle.c	2019-04-25 01:10:27.182803635 +0200
+--- ../cpython-3.8.0rc1/Modules/_pickle.c	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/_pickle.c	2019-10-10 22:19:39.000000000 -0700
 @@ -1,11 +1,11 @@
 -/* pickle accelerator C extensor: _pickle module.
 - *
@@ -55,7 +55,7 @@
  #endif
  
  #include "Python.h"
-@@ -706,7 +706,13 @@
+@@ -709,7 +709,13 @@
  static PyTypeObject Pickler_Type;
  static PyTypeObject Unpickler_Type;
  
@@ -69,7 +69,149 @@
  
  /*************************************************************************
   A custom hashtable mapping void* to Python ints. This is used by the pickler
-@@ -7794,11 +7800,25 @@
+@@ -1356,6 +1362,8 @@
+ {
+     assert(n != READ_WHOLE_LINE);
+ 
++    /* XXX add tests from ogrisel's use case */
++
+     /* Read from available buffer data, if any */
+     Py_ssize_t in_buffer = self->input_len - self->next_read_idx;
+     if (in_buffer > 0) {
+@@ -1371,11 +1379,22 @@
+     }
+ 
+     /* Read from file */
+-    if (!self->readinto) {
+-        return bad_readline();
+-    }
+-    if (_Unpickler_SkipConsumed(self) < 0) {
++    if (_Unpickler_SkipConsumed(self) < 0)
+         return -1;
++
++    Py_ssize_t read_size;
++
++    if (self->readinto == NULL) {
++        /* Call read() and memcpy */
++        /* XXX do we want this fallback? pickle.py doesn't have it */
++        char *s;
++        read_size = _Unpickler_ReadImpl(self, &s, n);
++        if (read_size < 0) {
++            return -1;
++        }
++        assert(read_size == n);
++        memcpy(buf, s, n);
++        return n;
+     }
+ 
+     /* Call readinto() into user buffer */
+@@ -1387,7 +1406,7 @@
+     if (read_size_obj == NULL) {
+         return -1;
+     }
+-    Py_ssize_t read_size = PyLong_AsSsize_t(read_size_obj);
++    read_size = PyLong_AsSsize_t(read_size_obj);
+     Py_DECREF(read_size_obj);
+ 
+     if (read_size < 0) {
+@@ -1606,17 +1625,19 @@
+     _Py_IDENTIFIER(readinto);
+     _Py_IDENTIFIER(readline);
+ 
++    /* Both 'peek' and 'readline' are optional, for compatibility */
+     if (_PyObject_LookupAttrId(file, &PyId_peek, &self->peek) < 0) {
+         return -1;
+     }
++    if (_PyObject_LookupAttrId(file, &PyId_readinto, &self->readinto) < 0) {
++        return -1;
++    }
+     (void)_PyObject_LookupAttrId(file, &PyId_read, &self->read);
+-    (void)_PyObject_LookupAttrId(file, &PyId_readinto, &self->readinto);
+     (void)_PyObject_LookupAttrId(file, &PyId_readline, &self->readline);
+-    if (!self->readline || !self->readinto || !self->read) {
++    if (self->readline == NULL || self->read == NULL) {
+         if (!PyErr_Occurred()) {
+             PyErr_SetString(PyExc_TypeError,
+-                            "file must have 'read', 'readinto' and "
+-                            "'readline' attributes");
++                            "file must have 'read' and 'readline' attributes");
+         }
+         Py_CLEAR(self->read);
+         Py_CLEAR(self->readinto);
+@@ -4870,10 +4891,10 @@
+     sizeof(PicklerMemoProxyObject),             /*tp_basicsize*/
+     0,
+     (destructor)PicklerMemoProxy_dealloc,       /* tp_dealloc */
+-    0,                                          /* tp_vectorcall_offset */
++    0,                                          /* tp_print */
+     0,                                          /* tp_getattr */
+     0,                                          /* tp_setattr */
+-    0,                                          /* tp_as_async */
++    0,                                          /* tp_compare */
+     0,                                          /* tp_repr */
+     0,                                          /* tp_as_number */
+     0,                                          /* tp_as_sequence */
+@@ -5031,10 +5052,10 @@
+     sizeof(PicklerObject),              /*tp_basicsize*/
+     0,                                  /*tp_itemsize*/
+     (destructor)Pickler_dealloc,        /*tp_dealloc*/
+-    0,                                  /*tp_vectorcall_offset*/
++    0,                                  /*tp_print*/
+     0,                                  /*tp_getattr*/
+     0,                                  /*tp_setattr*/
+-    0,                                  /*tp_as_async*/
++    0,                                  /*tp_reserved*/
+     0,                                  /*tp_repr*/
+     0,                                  /*tp_as_number*/
+     0,                                  /*tp_as_sequence*/
+@@ -7020,11 +7041,6 @@
+     PyObject *global;
+     PyObject *module;
+ 
+-    if (PySys_Audit("pickle.find_class", "OO",
+-                    module_name, global_name) < 0) {
+-        return NULL;
+-    }
+-
+     /* Try to map the old names used in Python 2.x to the new ones used in
+        Python 3.x.  We do this only with old pickle protocols and when the
+        user has not disabled the feature. */
+@@ -7408,10 +7424,10 @@
+     sizeof(UnpicklerMemoProxyObject),           /*tp_basicsize*/
+     0,
+     (destructor)UnpicklerMemoProxy_dealloc,     /* tp_dealloc */
+-    0,                                          /* tp_vectorcall_offset */
++    0,                                          /* tp_print */
+     0,                                          /* tp_getattr */
+     0,                                          /* tp_setattr */
+-    0,                                          /* tp_as_async */
++    0,                                          /* tp_compare */
+     0,                                          /* tp_repr */
+     0,                                          /* tp_as_number */
+     0,                                          /* tp_as_sequence */
+@@ -7579,10 +7595,10 @@
+     sizeof(UnpicklerObject),            /*tp_basicsize*/
+     0,                                  /*tp_itemsize*/
+     (destructor)Unpickler_dealloc,      /*tp_dealloc*/
+-    0,                                  /*tp_vectorcall_offset*/
++    0,                                  /*tp_print*/
+     0,                                  /*tp_getattr*/
+     0,                                  /*tp_setattr*/
+-    0,                                  /*tp_as_async*/
++    0,                                  /*tp_reserved*/
+     0,                                  /*tp_repr*/
+     0,                                  /*tp_as_number*/
+     0,                                  /*tp_as_sequence*/
+@@ -7790,7 +7806,7 @@
+ _pickle_load_impl(PyObject *module, PyObject *file, int fix_imports,
+                   const char *encoding, const char *errors,
+                   PyObject *buffers)
+-/*[clinic end generated code: output=250452d141c23e76 input=46c7c31c92f4f371]*/
++/*[clinic end generated code: output=250452d141c23e76 input=29fae982fe778156]*/
+ {
+     PyObject *result;
+     UnpicklerObject *unpickler = _Unpickler_New();
+@@ -7877,11 +7893,25 @@
      return NULL;
  }
  
@@ -95,7 +237,7 @@
      {NULL, NULL} /* sentinel */
  };
  
-@@ -7882,6 +7902,8 @@
+@@ -7965,6 +7995,8 @@
      Py_INCREF(&Unpickler_Type);
      if (PyModule_AddObject(m, "Unpickler", (PyObject *)&Unpickler_Type) < 0)
          return NULL;
@@ -104,31 +246,37 @@
      Py_INCREF(&PyPickleBuffer_Type);
      if (PyModule_AddObject(m, "PickleBuffer",
                             (PyObject *)&PyPickleBuffer_Type) < 0)
---- ../default/Lib/pickle.py	2019-04-24 23:48:48.962087635 +0200
-+++ pickle5/pickle.py	2019-04-25 01:10:27.182803635 +0200
-@@ -36,7 +36,7 @@
+--- ../cpython-3.8.0rc1/Lib/pickle.py	2019-10-10 22:44:17.000000000 -0700
++++ pickle5/pickle.py	2019-10-10 22:53:55.000000000 -0700
+@@ -36,11 +36,13 @@
  import codecs
  import _compat_pickle
  
--from _pickle import PickleBuffer
-+from ._pickle import PickleBuffer, _make_memoryview_readonly
- 
++from ._pickle import _make_memoryview_readonly
++
  __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
-            "Unpickler", "dump", "dumps", "load", "loads", "PickleBuffer"]
-@@ -546,7 +546,11 @@
-             rv = reduce(obj)
-         else:
-             # Check for a class with a custom metaclass; treat as regular class
--            if issubclass(t, type):
-+            try:
-+                issc = issubclass(t, type)
-+            except TypeError: # t is not a class (old Boost; see SF #502085)
-+                issc = False
-+            if issc:
-                 self.save_global(obj)
-                 return
+            "Unpickler", "dump", "dumps", "load", "loads"]
  
-@@ -1364,7 +1368,9 @@
+ try:
+-    from _pickle import PickleBuffer
++    from ._pickle import PickleBuffer
+     __all__.append("PickleBuffer")
+     _HAVE_PICKLE_BUFFER = True
+ except ImportError:
+@@ -566,7 +568,11 @@
+             else:
+                 # Check for a class with a custom metaclass; treat as regular
+                 # class
+-                if issubclass(t, type):
++                try:
++                    issc = issubclass(t, type)
++                except TypeError: # t is not a class (old Boost; see SF #502085)
++                    issc = False
++                if issc:
+                     self.save_global(obj)
+                     return
+ 
+@@ -1405,7 +1411,9 @@
          buf = self.stack[-1]
          with memoryview(buf) as m:
              if not m.readonly:
@@ -139,7 +287,15 @@
      dispatch[READONLY_BUFFER[0]] = load_readonly_buffer
  
      def load_short_binstring(self):
-@@ -1717,7 +1723,7 @@
+@@ -1568,7 +1576,6 @@
+ 
+     def find_class(self, module, name):
+         # Subclasses may override this.
+-        sys.audit('pickle.find_class', module, name)
+         if self.proto < 3 and self.fix_imports:
+             if (module, name) in _compat_pickle.NAME_MAPPING:
+                 module, name = _compat_pickle.NAME_MAPPING[(module, name)]
+@@ -1759,7 +1766,7 @@
  
  # Use the faster _pickle if possible
  try:
@@ -148,8 +304,8 @@
          PickleError,
          PicklingError,
          UnpicklingError,
---- ../default/Lib/pickletools.py	2019-04-24 21:34:21.505821080 +0200
-+++ pickle5/pickletools.py	2019-04-25 01:10:27.182803635 +0200
+--- ../cpython-3.8.0rc1/Lib/pickletools.py	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/pickletools.py	2019-10-10 22:43:59.000000000 -0700
 @@ -12,10 +12,11 @@
  
  import codecs
@@ -163,18 +319,18 @@
  __all__ = ['dis', 'genops', 'optimize']
  
  bytes_types = pickle.bytes_types
---- ../default/Lib/test/pickletester.py	2019-04-25 01:09:30.430092000 +0200
-+++ pickle5/test/pickletester.py	2019-04-25 01:10:27.182803635 +0200
-@@ -4,8 +4,6 @@
- import io
+--- ../cpython-3.8.0rc1/Lib/test/pickletester.py	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/test/pickletester.py	2019-10-10 22:39:58.000000000 -0700
+@@ -5,8 +5,6 @@
  import functools
  import os
+ import math
 -import pickle
 -import pickletools
  import shutil
  import struct
  import sys
-@@ -31,7 +29,8 @@
+@@ -32,7 +30,8 @@
      _2G, _4G, bigmemtest, reap_threads, forget,
      )
  
@@ -184,7 +340,7 @@
  
  requires_32b = unittest.skipUnless(sys.maxsize < 2**32,
                                     "test is only meaningful on 32-bit builds")
-@@ -1461,12 +1460,11 @@
+@@ -1445,12 +1444,11 @@
      # of 1.
      def dont_test_disassembly(self):
          from io import StringIO
@@ -198,20 +354,22 @@
              got = filelike.getvalue()
              self.assertEqual(expected, got)
  
---- ../default/Lib/test/test_pickle.py	2019-04-24 23:20:31.049670452 +0200
-+++ pickle5/test/test_pickle.py	2019-04-25 01:10:27.182803635 +0200
-@@ -1,7 +1,6 @@
+--- ../cpython-3.8.0rc1/Lib/test/test_pickle.py	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/test/test_pickle.py	2019-10-10 22:34:45.000000000 -0700
+@@ -1,7 +1,7 @@
  from _compat_pickle import (IMPORT_MAPPING, REVERSE_IMPORT_MAPPING,
                              NAME_MAPPING, REVERSE_NAME_MAPPING)
  import builtins
 -import pickle
++import pickle5 as pickle
  import io
  import collections
  import struct
-@@ -11,17 +10,18 @@
+@@ -11,19 +11,19 @@
  import unittest
  from test import support
  
+-from test.pickletester import AbstractHookTests
 -from test.pickletester import AbstractUnpickleTests
 -from test.pickletester import AbstractPickleTests
 -from test.pickletester import AbstractPickleModuleTests
@@ -219,7 +377,9 @@
 -from test.pickletester import AbstractIdentityPersistentPicklerTests
 -from test.pickletester import AbstractPicklerUnpicklerObjectTests
 -from test.pickletester import AbstractDispatchTableTests
+-from test.pickletester import AbstractCustomPicklerClass
 -from test.pickletester import BigmemPickleTests
++from .pickletester import AbstractHookTests
 +from .pickletester import AbstractUnpickleTests
 +from .pickletester import AbstractPickleTests
 +from .pickletester import AbstractPickleModuleTests
@@ -227,16 +387,16 @@
 +from .pickletester import AbstractIdentityPersistentPicklerTests
 +from .pickletester import AbstractPicklerUnpicklerObjectTests
 +from .pickletester import AbstractDispatchTableTests
++from .pickletester import AbstractCustomPicklerClass
 +from .pickletester import BigmemPickleTests
  
-+import pickle5 as pickle
  try:
 -    import _pickle
 +    from pickle5 import _pickle
      has_c_implementation = True
  except ImportError:
      has_c_implementation = False
-@@ -205,7 +205,7 @@
+@@ -212,7 +212,7 @@
  
  if has_c_implementation:
      class CPickleTests(AbstractPickleModuleTests):
@@ -245,31 +405,14 @@
  
      class CUnpicklerTests(PyUnpicklerTests):
          unpickler = _pickle.Unpickler
-@@ -508,7 +508,8 @@
-                       PyPicklerUnpicklerObjectTests,
-                       CPicklerUnpicklerObjectTests,
-                       CDispatchTableTests, CChainDispatchTableTests,
--                      InMemoryPickleTests, SizeofTests])
-+                      InMemoryPickleTests, SizeofTests
-+                      ])
-     support.run_unittest(*tests)
-     support.run_doctest(pickle)
- 
---- ../default/Lib/test/test_picklebuffer.py	2019-04-25 01:11:35.679661336 +0200
-+++ pickle5/test/test_picklebuffer.py	2019-04-25 01:11:42.103741713 +0200
-@@ -4,13 +4,14 @@
+--- ../cpython-3.8.0rc1/Lib/test/test_picklebuffer.py	2019-10-01 05:58:26.000000000 -0700
++++ pickle5/test/test_picklebuffer.py	2019-10-10 22:31:20.000000000 -0700
+@@ -4,7 +4,7 @@
  """
  
  import gc
 -from pickle import PickleBuffer
- import sys
++from pickle5 import PickleBuffer
  import weakref
  import unittest
  
- from test import support
- 
-+from pickle5 import PickleBuffer
-+
- 
- class B(bytes):
-     pass

--- a/patch
+++ b/patch
@@ -35,7 +35,7 @@
      PyObject_HEAD
      /* The view exported by the original object */
 --- ../cpython-3.8.0rc1/Modules/_pickle.c	2019-10-01 05:58:26.000000000 -0700
-+++ pickle5/_pickle.c	2019-10-10 22:19:39.000000000 -0700
++++ pickle5/_pickle.c	2019-10-11 00:33:54.000000000 -0700
 @@ -1,11 +1,11 @@
 -/* pickle accelerator C extensor: _pickle module.
 - *
@@ -69,7 +69,17 @@
  
  /*************************************************************************
   A custom hashtable mapping void* to Python ints. This is used by the pickler
-@@ -1356,6 +1362,8 @@
+@@ -1141,8 +1147,7 @@
+ _Pickler_SetProtocol(PicklerObject *self, PyObject *protocol, int fix_imports)
+ {
+     long proto;
+-
+-    if (protocol == Py_None) {
++    if (protocol == NULL || protocol == Py_None) {
+         proto = DEFAULT_PROTOCOL;
+     }
+     else {
+@@ -1356,6 +1361,8 @@
  {
      assert(n != READ_WHOLE_LINE);
  
@@ -78,7 +88,7 @@
      /* Read from available buffer data, if any */
      Py_ssize_t in_buffer = self->input_len - self->next_read_idx;
      if (in_buffer > 0) {
-@@ -1371,11 +1379,22 @@
+@@ -1371,11 +1378,22 @@
      }
  
      /* Read from file */
@@ -105,7 +115,7 @@
      }
  
      /* Call readinto() into user buffer */
-@@ -1387,7 +1406,7 @@
+@@ -1387,7 +1405,7 @@
      if (read_size_obj == NULL) {
          return -1;
      }
@@ -114,7 +124,7 @@
      Py_DECREF(read_size_obj);
  
      if (read_size < 0) {
-@@ -1606,17 +1625,19 @@
+@@ -1606,17 +1624,19 @@
      _Py_IDENTIFIER(readinto);
      _Py_IDENTIFIER(readline);
  
@@ -138,7 +148,7 @@
          }
          Py_CLEAR(self->read);
          Py_CLEAR(self->readinto);
-@@ -4870,10 +4891,10 @@
+@@ -4870,10 +4890,10 @@
      sizeof(PicklerMemoProxyObject),             /*tp_basicsize*/
      0,
      (destructor)PicklerMemoProxy_dealloc,       /* tp_dealloc */
@@ -151,7 +161,7 @@
      0,                                          /* tp_repr */
      0,                                          /* tp_as_number */
      0,                                          /* tp_as_sequence */
-@@ -5031,10 +5052,10 @@
+@@ -5031,10 +5051,10 @@
      sizeof(PicklerObject),              /*tp_basicsize*/
      0,                                  /*tp_itemsize*/
      (destructor)Pickler_dealloc,        /*tp_dealloc*/
@@ -164,7 +174,7 @@
      0,                                  /*tp_repr*/
      0,                                  /*tp_as_number*/
      0,                                  /*tp_as_sequence*/
-@@ -7020,11 +7041,6 @@
+@@ -7020,11 +7040,6 @@
      PyObject *global;
      PyObject *module;
  
@@ -176,7 +186,7 @@
      /* Try to map the old names used in Python 2.x to the new ones used in
         Python 3.x.  We do this only with old pickle protocols and when the
         user has not disabled the feature. */
-@@ -7408,10 +7424,10 @@
+@@ -7408,10 +7423,10 @@
      sizeof(UnpicklerMemoProxyObject),           /*tp_basicsize*/
      0,
      (destructor)UnpicklerMemoProxy_dealloc,     /* tp_dealloc */
@@ -189,7 +199,7 @@
      0,                                          /* tp_repr */
      0,                                          /* tp_as_number */
      0,                                          /* tp_as_sequence */
-@@ -7579,10 +7595,10 @@
+@@ -7579,10 +7594,10 @@
      sizeof(UnpicklerObject),            /*tp_basicsize*/
      0,                                  /*tp_itemsize*/
      (destructor)Unpickler_dealloc,      /*tp_dealloc*/
@@ -202,7 +212,7 @@
      0,                                  /*tp_repr*/
      0,                                  /*tp_as_number*/
      0,                                  /*tp_as_sequence*/
-@@ -7790,7 +7806,7 @@
+@@ -7790,7 +7805,7 @@
  _pickle_load_impl(PyObject *module, PyObject *file, int fix_imports,
                    const char *encoding, const char *errors,
                    PyObject *buffers)
@@ -211,7 +221,7 @@
  {
      PyObject *result;
      UnpicklerObject *unpickler = _Unpickler_New();
-@@ -7877,11 +7893,25 @@
+@@ -7877,11 +7892,25 @@
      return NULL;
  }
  
@@ -237,7 +247,7 @@
      {NULL, NULL} /* sentinel */
  };
  
-@@ -7965,6 +7995,8 @@
+@@ -7965,6 +7994,8 @@
      Py_INCREF(&Unpickler_Type);
      if (PyModule_AddObject(m, "Unpickler", (PyObject *)&Unpickler_Type) < 0)
          return NULL;
@@ -320,7 +330,7 @@
  
  bytes_types = pickle.bytes_types
 --- ../cpython-3.8.0rc1/Lib/test/pickletester.py	2019-10-01 05:58:26.000000000 -0700
-+++ pickle5/test/pickletester.py	2019-10-10 22:39:58.000000000 -0700
++++ pickle5/test/pickletester.py	2019-10-10 23:13:54.000000000 -0700
 @@ -5,8 +5,6 @@
  import functools
  import os
@@ -354,8 +364,24 @@
              got = filelike.getvalue()
              self.assertEqual(expected, got)
  
+@@ -2328,7 +2326,6 @@
+         elif frameless_start is not None:
+             self.assertLess(pos - frameless_start, self.FRAME_SIZE_MIN)
+ 
+-    @support.skip_if_pgo_task
+     def test_framing_many_objects(self):
+         obj = list(range(10**5))
+         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
+@@ -2418,7 +2415,6 @@
+                                 count_opcode(pickle.FRAME, pickled))
+                 self.assertEqual(obj, self.loads(some_frames_pickle))
+ 
+-    @support.skip_if_pgo_task
+     def test_framed_write_sizes_with_delayed_writer(self):
+         class ChunkAccumulator:
+             """Accumulate pickler output in a list of raw chunks."""
 --- ../cpython-3.8.0rc1/Lib/test/test_pickle.py	2019-10-01 05:58:26.000000000 -0700
-+++ pickle5/test/test_pickle.py	2019-10-10 22:34:45.000000000 -0700
++++ pickle5/test/test_pickle.py	2019-10-11 00:36:01.000000000 -0700
 @@ -1,7 +1,7 @@
  from _compat_pickle import (IMPORT_MAPPING, REVERSE_IMPORT_MAPPING,
                              NAME_MAPPING, REVERSE_NAME_MAPPING)

--- a/pickle5/_pickle.c
+++ b/pickle5/_pickle.c
@@ -1147,8 +1147,7 @@ static int
 _Pickler_SetProtocol(PicklerObject *self, PyObject *protocol, int fix_imports)
 {
     long proto;
-
-    if (protocol == Py_None) {
+    if (protocol == NULL || protocol == Py_None) {
         proto = DEFAULT_PROTOCOL;
     }
     else {

--- a/pickle5/_pickle.c
+++ b/pickle5/_pickle.c
@@ -3944,7 +3944,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
     const char newobj_ex_op = NEWOBJ_EX;
 
     size = PyTuple_Size(args);
-   if (size < 2 || size > 6) {
+    if (size < 2 || size > 6) {
         PyErr_SetString(st->PicklingError, "tuple returned by "
                         "__reduce__ must contain 2 through 6 elements");
         return -1;
@@ -4446,7 +4446,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
     if (reduce_value == NULL)
         goto error;
 
-reduce:
+  reduce:
     if (PyUnicode_Check(reduce_value)) {
         status = save_global(self, obj, reduce_value);
         goto done;

--- a/pickle5/_pickle.c
+++ b/pickle5/_pickle.c
@@ -621,6 +621,9 @@ typedef struct PicklerObject {
     PyObject *pers_func_self;   /* borrowed reference to self if pers_func
                                    is an unbound method, NULL otherwise */
     PyObject *dispatch_table;   /* private dispatch_table, can be NULL */
+    PyObject *reducer_override; /* hook for invoking user-defined callbacks
+                                   instead of save_global when pickling
+                                   functions and classes*/
 
     PyObject *write;            /* write() method of the output stream. */
     PyObject *output_buffer;    /* Write into a local bytearray buffer before
@@ -1125,6 +1128,7 @@ _Pickler_New(void)
     self->fast_memo = NULL;
     self->max_output_len = WRITE_BUF_SIZE;
     self->output_len = 0;
+    self->reducer_override = NULL;
 
     self->memo = PyMemoTable_New();
     self->output_buffer = PyBytes_FromStringAndSize(NULL,
@@ -1144,7 +1148,7 @@ _Pickler_SetProtocol(PicklerObject *self, PyObject *protocol, int fix_imports)
 {
     long proto;
 
-    if (protocol == NULL || protocol == Py_None) {
+    if (protocol == Py_None) {
         proto = DEFAULT_PROTOCOL;
     }
     else {
@@ -1395,9 +1399,13 @@ _Unpickler_ReadInto(UnpicklerObject *self, char *buf, Py_ssize_t n)
 
     /* Call readinto() into user buffer */
     PyObject *buf_obj = PyMemoryView_FromMemory(buf, n, PyBUF_WRITE);
-    if (buf_obj == NULL)
+    if (buf_obj == NULL) {
         return -1;
+    }
     PyObject *read_size_obj = _Pickle_FastCall(self->readinto, buf_obj);
+    if (read_size_obj == NULL) {
+        return -1;
+    }
     read_size = PyLong_AsSsize_t(read_size_obj);
     Py_DECREF(read_size_obj);
 
@@ -1408,8 +1416,9 @@ _Unpickler_ReadInto(UnpicklerObject *self, char *buf, Py_ssize_t n)
         }
         return -1;
     }
-    if (read_size < n)
+    if (read_size < n) {
         return bad_readline();
+    }
     return n;
 }
 
@@ -1665,7 +1674,7 @@ _Unpickler_SetInputEncoding(UnpicklerObject *self,
 static int
 _Unpickler_SetBuffers(UnpicklerObject *self, PyObject *buffers)
 {
-    if (buffers == NULL) {
+    if (buffers == NULL || buffers == Py_None) {
         self->buffers = NULL;
     }
     else {
@@ -2131,7 +2140,7 @@ save_long(PicklerObject *self, PyObject *obj)
         /* How many bytes do we need?  There are nbits >> 3 full
          * bytes of data, and nbits & 7 leftover bits.  If there
          * are any leftover bits, then we clearly need another
-         * byte.  Wnat's not so obvious is that we *probably*
+         * byte.  What's not so obvious is that we *probably*
          * need another byte even if there aren't any leftovers:
          * the most-significant bit of the most-significant byte
          * acts like a sign bit, and it's usually got a sense
@@ -2364,7 +2373,8 @@ _save_bytes_data(PicklerObject *self, PyObject *obj, const char *data,
     }
     else {
         PyErr_SetString(PyExc_OverflowError,
-                        "cannot serialize a bytes object larger than 4 GiB");
+                        "serializing a bytes object larger than 4 GiB "
+                        "requires pickle protocol 4 or higher");
         return -1;
     }
 
@@ -2394,7 +2404,7 @@ save_bytes(PicklerObject *self, PyObject *obj)
            Python 2 *and* the appropriate 'bytes' object when unpickled
            using Python 3. Again this is a hack and we don't need to do this
            with newer protocols. */
-        PyObject *reduce_value = NULL;
+        PyObject *reduce_value;
         int status;
 
         if (PyBytes_GET_SIZE(obj) == 0) {
@@ -2599,7 +2609,10 @@ raw_unicode_escape(PyObject *obj)
             *p++ = Py_hexdigits[ch & 15];
         }
         /* Map 16-bit characters, '\\' and '\n' to '\uxxxx' */
-        else if (ch >= 256 || ch == '\\' || ch == '\n') {
+        else if (ch >= 256 ||
+                 ch == '\\' || ch == 0 || ch == '\n' || ch == '\r' ||
+                 ch == 0x1a)
+        {
             /* -1: subtract 1 preallocated byte */
             p = _PyBytesWriter_Prepare(&writer, p, 6-1);
             if (p == NULL)
@@ -2670,7 +2683,8 @@ write_unicode_binary(PicklerObject *self, PyObject *obj)
     }
     else {
         PyErr_SetString(PyExc_OverflowError,
-                        "cannot serialize a string larger than 4GiB");
+                        "serializing a string larger than 4 GiB "
+                        "requires pickle protocol 4 or higher");
         Py_XDECREF(encoded);
         return -1;
     }
@@ -3919,6 +3933,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
     PyObject *state = NULL;
     PyObject *listitems = Py_None;
     PyObject *dictitems = Py_None;
+    PyObject *state_setter = Py_None;
     PickleState *st = _Pickle_GetGlobalState();
     Py_ssize_t size;
     int use_newobj = 0, use_newobj_ex = 0;
@@ -3929,14 +3944,15 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
     const char newobj_ex_op = NEWOBJ_EX;
 
     size = PyTuple_Size(args);
-    if (size < 2 || size > 5) {
+   if (size < 2 || size > 6) {
         PyErr_SetString(st->PicklingError, "tuple returned by "
-                        "__reduce__ must contain 2 through 5 elements");
+                        "__reduce__ must contain 2 through 6 elements");
         return -1;
     }
 
-    if (!PyArg_UnpackTuple(args, "save_reduce", 2, 5,
-                           &callable, &argtup, &state, &listitems, &dictitems))
+    if (!PyArg_UnpackTuple(args, "save_reduce", 2, 6,
+                           &callable, &argtup, &state, &listitems, &dictitems,
+                           &state_setter))
         return -1;
 
     if (!PyCallable_Check(callable)) {
@@ -3968,6 +3984,15 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         PyErr_Format(st->PicklingError, "fifth element of the tuple "
                      "returned by __reduce__ must be an iterator, not %s",
                      Py_TYPE(dictitems)->tp_name);
+        return -1;
+    }
+
+    if (state_setter == Py_None)
+        state_setter = NULL;
+    else if (!PyCallable_Check(state_setter)) {
+        PyErr_Format(st->PicklingError, "sixth element of the tuple "
+                     "returned by __reduce__ must be a function, not %s",
+                     Py_TYPE(state_setter)->tp_name);
         return -1;
     }
 
@@ -4190,11 +4215,32 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         return -1;
 
     if (state) {
-        if (save(self, state, 0) < 0 ||
-            _Pickler_Write(self, &build_op, 1) < 0)
-            return -1;
-    }
+        if (state_setter == NULL) {
+            if (save(self, state, 0) < 0 ||
+                _Pickler_Write(self, &build_op, 1) < 0)
+                return -1;
+        }
+        else {
 
+            /* If a state_setter is specified, call it instead of load_build to
+             * update obj's with its previous state.
+             * The first 4 save/write instructions push state_setter and its
+             * tuple of expected arguments (obj, state) onto the stack. The
+             * REDUCE opcode triggers the state_setter(obj, state) function
+             * call. Finally, because state-updating routines only do in-place
+             * modification, the whole operation has to be stack-transparent.
+             * Thus, we finally pop the call's output from the stack.*/
+
+            const char tupletwo_op = TUPLE2;
+            const char pop_op = POP;
+            if (save(self, state_setter, 0) < 0 ||
+                save(self, obj, 0) < 0 || save(self, state, 0) < 0 ||
+                _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
+                _Pickler_Write(self, &reduce_op, 1) < 0 ||
+                _Pickler_Write(self, &pop_op, 1) < 0)
+                return -1;
+        }
+    }
     return 0;
 }
 
@@ -4291,7 +4337,25 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         status = save_picklebuffer(self, obj);
         goto done;
     }
-    else if (type == &PyType_Type) {
+
+    /* Now, check reducer_override.  If it returns NotImplemented,
+     * fallback to save_type or save_global, and then perhaps to the
+     * regular reduction mechanism.
+     */
+    if (self->reducer_override != NULL) {
+        reduce_value = PyObject_CallFunctionObjArgs(self->reducer_override,
+                                                    obj, NULL);
+        if (reduce_value == NULL) {
+            goto error;
+        }
+        if (reduce_value != Py_NotImplemented) {
+            goto reduce;
+        }
+        Py_DECREF(reduce_value);
+        reduce_value = NULL;
+    }
+
+    if (type == &PyType_Type) {
         status = save_type(self, obj);
         goto done;
     }
@@ -4342,7 +4406,6 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
         _Py_IDENTIFIER(__reduce__);
         _Py_IDENTIFIER(__reduce_ex__);
 
-
         /* XXX: If the __reduce__ method is defined, __reduce_ex__ is
            automatically defined as __reduce__. While this is convenient, this
            make it impossible to know which method was actually called. Of
@@ -4363,14 +4426,15 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
             }
         }
         else {
-            PickleState *st = _Pickle_GetGlobalState();
-
             /* Check for a __reduce__ method. */
-            reduce_func = _PyObject_GetAttrId(obj, &PyId___reduce__);
+            if (_PyObject_LookupAttrId(obj, &PyId___reduce__, &reduce_func) < 0) {
+                goto error;
+            }
             if (reduce_func != NULL) {
                 reduce_value = _PyObject_CallNoArg(reduce_func);
             }
             else {
+                PickleState *st = _Pickle_GetGlobalState();
                 PyErr_Format(st->PicklingError,
                              "can't pickle '%.200s' object: %R",
                              type->tp_name, obj);
@@ -4382,6 +4446,7 @@ save(PicklerObject *self, PyObject *obj, int pers_save)
     if (reduce_value == NULL)
         goto error;
 
+reduce:
     if (PyUnicode_Check(reduce_value)) {
         status = save_global(self, obj, reduce_value);
         goto done;
@@ -4413,6 +4478,20 @@ static int
 dump(PicklerObject *self, PyObject *obj)
 {
     const char stop_op = STOP;
+    PyObject *tmp;
+    _Py_IDENTIFIER(reducer_override);
+
+    if (_PyObject_LookupAttrId((PyObject *)self, &PyId_reducer_override,
+                               &tmp) < 0) {
+        return -1;
+    }
+    /* Cache the reducer_override method, if it exists. */
+    if (tmp != NULL) {
+        Py_XSETREF(self->reducer_override, tmp);
+    }
+    else {
+        Py_CLEAR(self->reducer_override);
+    }
 
     if (self->proto >= 2) {
         char header[2];
@@ -4537,6 +4616,7 @@ Pickler_dealloc(PicklerObject *self)
     Py_XDECREF(self->pers_func);
     Py_XDECREF(self->dispatch_table);
     Py_XDECREF(self->fast_memo);
+    Py_XDECREF(self->reducer_override);
     Py_XDECREF(self->buffer_callback);
 
     PyMemoTable_Del(self->memo);
@@ -4551,6 +4631,7 @@ Pickler_traverse(PicklerObject *self, visitproc visit, void *arg)
     Py_VISIT(self->pers_func);
     Py_VISIT(self->dispatch_table);
     Py_VISIT(self->fast_memo);
+    Py_VISIT(self->reducer_override);
     Py_VISIT(self->buffer_callback);
     return 0;
 }
@@ -4563,6 +4644,7 @@ Pickler_clear(PicklerObject *self)
     Py_CLEAR(self->pers_func);
     Py_CLEAR(self->dispatch_table);
     Py_CLEAR(self->fast_memo);
+    Py_CLEAR(self->reducer_override);
     Py_CLEAR(self->buffer_callback);
 
     if (self->memo != NULL) {
@@ -4579,9 +4661,9 @@ Pickler_clear(PicklerObject *self)
 _pickle.Pickler.__init__
 
   file: object
-  protocol: object = NULL
+  protocol: object = None
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 This takes a binary file for writing a pickle data stream.
 
@@ -4602,9 +4684,16 @@ If *fix_imports* is True and protocol is less than 3, pickle will try
 to map the new Python 3 names to the old module names used in Python
 2, so that the pickle data stream is readable with Python 2.
 
-If *buffer_callback* is None (the default), buffer views are serialized
-into *file* as part of the pickle stream.  It is an error if
-*buffer_callback* is not None and *protocol* is None or smaller than 5.
+If *buffer_callback* is None (the default), buffer views are
+serialized into *file* as part of the pickle stream.
+
+If *buffer_callback* is not None, then it can be called any number
+of times with a buffer view.  If the callback returns a false value
+(such as None), the given buffer is out-of-band; otherwise the
+buffer is serialized in-band, i.e. inside the pickle stream.
+
+It is an error if *buffer_callback* is not None and *protocol*
+is None or smaller than 5.
 
 [clinic start generated code]*/
 
@@ -4612,7 +4701,7 @@ static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
                               PyObject *protocol, int fix_imports,
                               PyObject *buffer_callback)
-/*[clinic end generated code: output=0abedc50590d259b input=10e101f062872d3c]*/
+/*[clinic end generated code: output=0abedc50590d259b input=bb886e00443a7811]*/
 {
     _Py_IDENTIFIER(persistent_id);
     _Py_IDENTIFIER(dispatch_table);
@@ -5437,8 +5526,9 @@ load_counted_bytearray(UnpicklerObject *self)
     Py_ssize_t size;
     char *s;
 
-    if (_Unpickler_Read(self, &s, 8) < 0)
+    if (_Unpickler_Read(self, &s, 8) < 0) {
         return -1;
+    }
 
     size = calc_binsize(s, 8);
     if (size < 0) {
@@ -5449,8 +5539,9 @@ load_counted_bytearray(UnpicklerObject *self)
     }
 
     bytearray = PyByteArray_FromStringAndSize(NULL, size);
-    if (bytearray == NULL)
+    if (bytearray == NULL) {
         return -1;
+    }
     if (_Unpickler_ReadInto(self, PyByteArray_AS_STRING(bytearray), size) < 0) {
         Py_DECREF(bytearray);
         return -1;
@@ -5488,8 +5579,9 @@ static int
 load_readonly_buffer(UnpicklerObject *self)
 {
     Py_ssize_t len = Py_SIZE(self->stack);
-    if (len <= self->stack->fence)
+    if (len <= self->stack->fence) {
         return Pdata_stack_underflow(self->stack);
+    }
 
     PyObject *obj = self->stack->data[len - 1];
     PyObject *view = PyMemoryView_FromObject(obj);
@@ -6377,7 +6469,9 @@ do_append(UnpicklerObject *self, Py_ssize_t x)
         PyObject *extend_func;
         _Py_IDENTIFIER(extend);
 
-        extend_func = _PyObject_GetAttrId(list, &PyId_extend);
+        if (_PyObject_LookupAttrId(list, &PyId_extend, &extend_func) < 0) {
+            return -1;
+        }
         if (extend_func != NULL) {
             slice = Pdata_poplist(self->stack, x);
             if (!slice) {
@@ -6397,7 +6491,6 @@ do_append(UnpicklerObject *self, Py_ssize_t x)
             /* Even if the PEP 307 requires extend() and append() methods,
                fall back on append() if the object has no extend() method
                for backward compatibility. */
-            PyErr_Clear();
             append_func = _PyObject_GetAttrId(list, &PyId_append);
             if (append_func == NULL)
                 return -1;
@@ -7125,7 +7218,7 @@ _pickle.Unpickler.__init__
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 This takes a binary file for reading a pickle data stream.
 
@@ -7153,7 +7246,7 @@ static int
 _pickle_Unpickler___init___impl(UnpicklerObject *self, PyObject *file,
                                 int fix_imports, const char *encoding,
                                 const char *errors, PyObject *buffers)
-/*[clinic end generated code: output=09f0192649ea3f85 input=da4b62d9edb68700]*/
+/*[clinic end generated code: output=09f0192649ea3f85 input=ca4c1faea9553121]*/
 {
     _Py_IDENTIFIER(persistent_load);
 
@@ -7545,10 +7638,10 @@ _pickle.dump
 
   obj: object
   file: object
-  protocol: object = NULL
+  protocol: object = None
   *
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 Write a pickled representation of obj to the open file object file.
 
@@ -7583,7 +7676,7 @@ static PyObject *
 _pickle_dump_impl(PyObject *module, PyObject *obj, PyObject *file,
                   PyObject *protocol, int fix_imports,
                   PyObject *buffer_callback)
-/*[clinic end generated code: output=706186dba996490c input=2f035f02cc0f9547]*/
+/*[clinic end generated code: output=706186dba996490c input=cfdcaf573ed6e46c]*/
 {
     PicklerObject *pickler = _Pickler_New();
 
@@ -7618,10 +7711,10 @@ _pickle_dump_impl(PyObject *module, PyObject *obj, PyObject *file,
 _pickle.dumps
 
   obj: object
-  protocol: object = NULL
+  protocol: object = None
   *
   fix_imports: bool = True
-  buffer_callback: object = NULL
+  buffer_callback: object = None
 
 Return the pickled representation of the object as a bytes object.
 
@@ -7647,7 +7740,7 @@ into *file* as part of the pickle stream.  It is an error if
 static PyObject *
 _pickle_dumps_impl(PyObject *module, PyObject *obj, PyObject *protocol,
                    int fix_imports, PyObject *buffer_callback)
-/*[clinic end generated code: output=fbab0093a5580fdf input=001f167df711b9f1]*/
+/*[clinic end generated code: output=fbab0093a5580fdf input=9f334d535ff7194f]*/
 {
     PyObject *result;
     PicklerObject *pickler = _Pickler_New();
@@ -7682,7 +7775,7 @@ _pickle.load
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 Read and return an object from the pickle data stored in a file.
 
@@ -7750,7 +7843,7 @@ _pickle.loads
   fix_imports: bool = True
   encoding: str = 'ASCII'
   errors: str = 'strict'
-  buffers: object = NULL
+  buffers: object(c_default="NULL") = ()
 
 Read and return an object from the given pickle data.
 
@@ -7772,7 +7865,7 @@ static PyObject *
 _pickle_loads_impl(PyObject *module, PyObject *data, int fix_imports,
                    const char *encoding, const char *errors,
                    PyObject *buffers)
-/*[clinic end generated code: output=82ac1e6b588e6d02 input=c6004393f8276867]*/
+/*[clinic end generated code: output=82ac1e6b588e6d02 input=9c2ab6a0960185ea]*/
 {
     PyObject *result;
     UnpicklerObject *unpickler = _Unpickler_New();

--- a/pickle5/clinic/_pickle.c.h
+++ b/pickle5/clinic/_pickle.c.h
@@ -85,9 +85,16 @@ PyDoc_STRVAR(_pickle_Pickler___init____doc__,
 "to map the new Python 3 names to the old module names used in Python\n"
 "2, so that the pickle data stream is readable with Python 2.\n"
 "\n"
-"If *buffer_callback* is None (the default), buffer views are serialized\n"
-"into *file* as part of the pickle stream.  It is an error if\n"
-"*buffer_callback* is not None and *protocol* is None or smaller than 5.");
+"If *buffer_callback* is None (the default), buffer views are\n"
+"serialized into *file* as part of the pickle stream.\n"
+"\n"
+"If *buffer_callback* is not None, then it can be called any number\n"
+"of times with a buffer view.  If the callback returns a false value\n"
+"(such as None), the given buffer is out-of-band; otherwise the\n"
+"buffer is serialized in-band, i.e. inside the pickle stream.\n"
+"\n"
+"It is an error if *buffer_callback* is not None and *protocol*\n"
+"is None or smaller than 5.");
 
 static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
@@ -105,9 +112,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 1, 4, 0, argsbuf);
     if (!fastargs) {
@@ -285,7 +292,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=None)\n"
+"          buffers=())\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -495,9 +502,9 @@ _pickle_dump(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 3, 0, argsbuf);
     if (!args) {
@@ -575,9 +582,9 @@ _pickle_dumps(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *argsbuf[4];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *obj;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
@@ -616,7 +623,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=None)\n"
+"     errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -728,7 +735,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=None)\n"
+"      errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"

--- a/pickle5/clinic/_pickle.c.h
+++ b/pickle5/clinic/_pickle.c.h
@@ -112,9 +112,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
     PyObject *file;
-    PyObject *protocol = Py_None;
+    PyObject *protocol = NULL;
     int fix_imports = 1;
-    PyObject *buffer_callback = Py_None;
+    PyObject *buffer_callback = NULL;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 1, 4, 0, argsbuf);
     if (!fastargs) {
@@ -292,7 +292,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=())\n"
+"          buffers=None)\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -502,9 +502,9 @@ _pickle_dump(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = Py_None;
+    PyObject *protocol = NULL;
     int fix_imports = 1;
-    PyObject *buffer_callback = Py_None;
+    PyObject *buffer_callback = NULL;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 3, 0, argsbuf);
     if (!args) {
@@ -582,9 +582,9 @@ _pickle_dumps(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *argsbuf[4];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *obj;
-    PyObject *protocol = Py_None;
+    PyObject *protocol = NULL;
     int fix_imports = 1;
-    PyObject *buffer_callback = Py_None;
+    PyObject *buffer_callback = NULL;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
@@ -623,7 +623,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=())\n"
+"     errors=\'strict\', buffers=None)\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -735,7 +735,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=())\n"
+"      errors=\'strict\', buffers=None)\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"

--- a/pickle5/picklebufobject.c
+++ b/pickle5/picklebufobject.c
@@ -208,7 +208,7 @@ static PyMethodDef picklebuf_methods[] = {
 PyTypeObject PyPickleBuffer_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "pickle.PickleBuffer",
-    .tp_doc = "Out-of-band buffer",
+    .tp_doc = "Wrapper for potentially out-of-band buffers",
     .tp_basicsize = sizeof(PyPickleBufferObject),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = picklebuf_new,

--- a/pickle5/test/pickletester.py
+++ b/pickle5/test/pickletester.py
@@ -4,6 +4,7 @@ import dbm
 import io
 import functools
 import os
+import math
 import shutil
 import struct
 import sys
@@ -69,23 +70,6 @@ class UnseekableIO(io.BytesIO):
 
     def tell(self):
         raise io.UnsupportedOperation
-
-
-class TrivialReadableIO:
-    """
-    A readable file object that doesn't support readinto().
-    """
-    def __init__(self, *args, **kwargs):
-        self._bio = io.BytesIO(*args, **kwargs)
-
-    def read(self, n):
-        return self._bio.read(n)
-
-    def readline(self, n=None):
-        return self._bio.readline(n)
-
-    def getvalue(self):
-        return self._bio.getvalue()
 
 
 # We can't very well test the extension registry without putting known stuff
@@ -2342,6 +2326,7 @@ class AbstractPickleTests(unittest.TestCase):
         elif frameless_start is not None:
             self.assertLess(pos - frameless_start, self.FRAME_SIZE_MIN)
 
+    @support.skip_if_pgo_task
     def test_framing_many_objects(self):
         obj = list(range(10**5))
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
@@ -2414,7 +2399,7 @@ class AbstractPickleTests(unittest.TestCase):
 
         frame_size = self.FRAME_SIZE_TARGET
         num_frames = 20
-        # Large byte objects (dict values) intermitted with small objects
+        # Large byte objects (dict values) intermittent with small objects
         # (dict keys)
         for bytes_type in (bytes, bytearray):
             obj = {i: bytes_type([i]) * frame_size for i in range(num_frames)}
@@ -2431,6 +2416,7 @@ class AbstractPickleTests(unittest.TestCase):
                                 count_opcode(pickle.FRAME, pickled))
                 self.assertEqual(obj, self.loads(some_frames_pickle))
 
+    @support.skip_if_pgo_task
     def test_framed_write_sizes_with_delayed_writer(self):
         class ChunkAccumulator:
             """Accumulate pickler output in a list of raw chunks."""
@@ -2779,6 +2765,11 @@ class AbstractPickleTests(unittest.TestCase):
             with self.assertRaises(pickle.UnpicklingError):
                 self.loads(data, buffers=[])
 
+    def test_inband_accept_default_buffers_argument(self):
+        for proto in range(5, pickle.HIGHEST_PROTOCOL + 1):
+            data_pickled = self.dumps(1, proto, buffer_callback=None)
+            data = self.loads(data_pickled, buffers=None)
+
     @unittest.skipIf(np is None, "Test needs Numpy")
     def test_buffers_numpy(self):
         def check_no_copy(x, y):
@@ -3081,22 +3072,20 @@ class BadGetattr:
 class AbstractPickleModuleTests(unittest.TestCase):
 
     def test_dump_closed_file(self):
-        import os
         f = open(TESTFN, "wb")
         try:
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            os.remove(TESTFN)
+            support.unlink(TESTFN)
 
     def test_load_closed_file(self):
-        import os
         f = open(TESTFN, "wb")
         try:
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            os.remove(TESTFN)
+            support.unlink(TESTFN)
 
     def test_load_from_and_dump_to_file(self):
         stream = io.BytesIO()
@@ -3119,6 +3108,19 @@ class AbstractPickleModuleTests(unittest.TestCase):
         self.dumps(123, protocol=-1)
         self.Pickler(f, -1)
         self.Pickler(f, protocol=-1)
+
+    def test_dump_text_file(self):
+        f = open(TESTFN, "w")
+        try:
+            for proto in protocols:
+                self.assertRaises(TypeError, self.dump, 123, f, proto)
+        finally:
+            f.close()
+            support.unlink(TESTFN)
+
+    def test_incomplete_input(self):
+        s = io.BytesIO(b"X''.")
+        self.assertRaises((EOFError, struct.error, pickle.UnpicklingError), self.load, s)
 
     def test_bad_init(self):
         # Test issue3664 (pickle can segfault from a badly initialized Pickler).
@@ -3396,22 +3398,6 @@ class AbstractPicklerUnpicklerObjectTests(unittest.TestCase):
                 unpickler = self.unpickler_class(f)
                 self.assertEqual(unpickler.load(), data)
 
-    def test_unpickling_trivial_io(self):
-        # Check unpickling with an io class that doesn't have readinto()
-        sizes = [1, 16, 1000, 2**10]
-        data = [(b"x" * size, bytearray(b"x") * size) for size in sizes]
-        for proto in protocols:
-            with self.subTest(proto=proto):
-                bio = io.BytesIO()
-                pickler = self.pickler_class(bio, protocol=proto)
-                pickler.dump(data)
-                N = 5
-                f = TrivialReadableIO(bio.getvalue() * N)
-                unpickler = self.unpickler_class(f)
-                for i in range(N):
-                    self.assertEqual(unpickler.load(), data)
-                self.assertRaises(EOFError, unpickler.load)
-
 
 # Tests for dispatch_table attribute
 
@@ -3422,7 +3408,93 @@ class AAA(object):
         return str, (REDUCE_A,)
 
 class BBB(object):
-    pass
+    def __init__(self):
+        # Add an instance attribute to enable state-saving routines at pickling
+        # time.
+        self.a = "some attribute"
+
+    def __setstate__(self, state):
+        self.a = "BBB.__setstate__"
+
+
+def setstate_bbb(obj, state):
+    """Custom state setter for BBB objects
+
+    Such callable may be created by other persons than the ones who created the
+    BBB class. If passed as the state_setter item of a custom reducer, this
+    allows for custom state setting behavior of BBB objects. One can think of
+    it as the analogous of list_setitems or dict_setitems but for foreign
+    classes/functions.
+    """
+    obj.a = "custom state_setter"
+
+
+
+class AbstractCustomPicklerClass:
+    """Pickler implementing a reducing hook using reducer_override."""
+    def reducer_override(self, obj):
+        obj_name = getattr(obj, "__name__", None)
+
+        if obj_name == 'f':
+            # asking the pickler to save f as 5
+            return int, (5, )
+
+        if obj_name == 'MyClass':
+            return str, ('some str',)
+
+        elif obj_name == 'g':
+            # in this case, the callback returns an invalid result (not a 2-5
+            # tuple or a string), the pickler should raise a proper error.
+            return False
+
+        elif obj_name == 'h':
+            # Simulate a case when the reducer fails. The error should
+            # be propagated to the original ``dump`` call.
+            raise ValueError('The reducer just failed')
+
+        return NotImplemented
+
+class AbstractHookTests(unittest.TestCase):
+    def test_pickler_hook(self):
+        # test the ability of a custom, user-defined CPickler subclass to
+        # override the default reducing routines of any type using the method
+        # reducer_override
+
+        def f():
+            pass
+
+        def g():
+            pass
+
+        def h():
+            pass
+
+        class MyClass:
+            pass
+
+        for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                bio = io.BytesIO()
+                p = self.pickler_class(bio, proto)
+
+                p.dump([f, MyClass, math.log])
+                new_f, some_str, math_log = pickle.loads(bio.getvalue())
+
+                self.assertEqual(new_f, 5)
+                self.assertEqual(some_str, 'some str')
+                # math.log does not have its usual reducer overriden, so the
+                # custom reduction callback should silently direct the pickler
+                # to the default pickling by attribute, by returning
+                # NotImplemented
+                self.assertIs(math_log, math.log)
+
+                with self.assertRaises(pickle.PicklingError):
+                    p.dump(g)
+
+                with self.assertRaisesRegex(
+                        ValueError, 'The reducer just failed'):
+                    p.dump(h)
+
 
 class AbstractDispatchTableTests(unittest.TestCase):
 
@@ -3510,6 +3582,25 @@ class AbstractDispatchTableTests(unittest.TestCase):
         self.assertIsInstance(custom_load_dump(b), BBB)
         self.assertEqual(default_load_dump(a), REDUCE_A)
         self.assertIsInstance(default_load_dump(b), BBB)
+
+        # End-to-end testing of save_reduce with the state_setter keyword
+        # argument. This is a dispatch_table test as the primary goal of
+        # state_setter is to tweak objects reduction behavior.
+        # In particular, state_setter is useful when the default __setstate__
+        # behavior is not flexible enough.
+
+        # No custom reducer for b has been registered for now, so
+        # BBB.__setstate__ should be used at unpickling time
+        self.assertEqual(default_load_dump(b).a, "BBB.__setstate__")
+
+        def reduce_bbb(obj):
+            return BBB, (), obj.__dict__, None, None, setstate_bbb
+
+        dispatch_table[BBB] = reduce_bbb
+
+        # The custom reducer reduce_bbb includes a state setter, that should
+        # have priority over BBB.__setstate__
+        self.assertEqual(custom_load_dump(b).a, "custom state_setter")
 
 
 if __name__ == "__main__":

--- a/pickle5/test/pickletester.py
+++ b/pickle5/test/pickletester.py
@@ -2326,7 +2326,6 @@ class AbstractPickleTests(unittest.TestCase):
         elif frameless_start is not None:
             self.assertLess(pos - frameless_start, self.FRAME_SIZE_MIN)
 
-    @support.skip_if_pgo_task
     def test_framing_many_objects(self):
         obj = list(range(10**5))
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
@@ -2416,7 +2415,6 @@ class AbstractPickleTests(unittest.TestCase):
                                 count_opcode(pickle.FRAME, pickled))
                 self.assertEqual(obj, self.loads(some_frames_pickle))
 
-    @support.skip_if_pgo_task
     def test_framed_write_sizes_with_delayed_writer(self):
         class ChunkAccumulator:
             """Accumulate pickler output in a list of raw chunks."""

--- a/pickle5/test/test_pickle.py
+++ b/pickle5/test/test_pickle.py
@@ -272,7 +272,7 @@ if has_c_implementation:
         check_sizeof = support.check_sizeof
 
         def test_pickler(self):
-            basesize = support.calcobjsize('6P2n3i2n3i2P')
+            basesize = support.calcobjsize('7P2n3i2n3i2P')
             p = _pickle.Pickler(io.BytesIO())
             self.assertEqual(object.__sizeof__(p), basesize)
             MT_size = struct.calcsize('3nP0n')

--- a/pickle5/test/test_pickle.py
+++ b/pickle5/test/test_pickle.py
@@ -272,7 +272,7 @@ if has_c_implementation:
         check_sizeof = support.check_sizeof
 
         def test_pickler(self):
-            basesize = support.calcobjsize('7P2n3i2n3i2P')
+            basesize = support.calcobjsize('6P2n3i2n3i2P')
             p = _pickle.Pickler(io.BytesIO())
             self.assertEqual(object.__sizeof__(p), basesize)
             MT_size = struct.calcsize('3nP0n')

--- a/pickle5/test/test_pickle.py
+++ b/pickle5/test/test_pickle.py
@@ -1,6 +1,7 @@
 from _compat_pickle import (IMPORT_MAPPING, REVERSE_IMPORT_MAPPING,
                             NAME_MAPPING, REVERSE_NAME_MAPPING)
 import builtins
+import pickle5 as pickle
 import io
 import collections
 import struct
@@ -10,6 +11,7 @@ import weakref
 import unittest
 from test import support
 
+from .pickletester import AbstractHookTests
 from .pickletester import AbstractUnpickleTests
 from .pickletester import AbstractPickleTests
 from .pickletester import AbstractPickleModuleTests
@@ -17,16 +19,14 @@ from .pickletester import AbstractPersistentPicklerTests
 from .pickletester import AbstractIdentityPersistentPicklerTests
 from .pickletester import AbstractPicklerUnpicklerObjectTests
 from .pickletester import AbstractDispatchTableTests
+from .pickletester import AbstractCustomPicklerClass
 from .pickletester import BigmemPickleTests
 
-import pickle5 as pickle
 try:
     from pickle5 import _pickle
     has_c_implementation = True
 except ImportError:
     has_c_implementation = False
-
-#has_c_implementation = False
 
 
 class PyPickleTests(AbstractPickleModuleTests):
@@ -203,6 +203,13 @@ class PyChainDispatchTableTests(AbstractDispatchTableTests):
         return collections.ChainMap({}, pickle.dispatch_table)
 
 
+class PyPicklerHookTests(AbstractHookTests):
+    class CustomPyPicklerClass(pickle._Pickler,
+                               AbstractCustomPicklerClass):
+        pass
+    pickler_class = CustomPyPicklerClass
+
+
 if has_c_implementation:
     class CPickleTests(AbstractPickleModuleTests):
         from pickle5._pickle import dump, dumps, load, loads, Pickler, Unpickler
@@ -255,12 +262,17 @@ if has_c_implementation:
         def get_dispatch_table(self):
             return collections.ChainMap({}, pickle.dispatch_table)
 
+    class CPicklerHookTests(AbstractHookTests):
+        class CustomCPicklerClass(_pickle.Pickler, AbstractCustomPicklerClass):
+            pass
+        pickler_class = CustomCPicklerClass
+
     @support.cpython_only
     class SizeofTests(unittest.TestCase):
         check_sizeof = support.check_sizeof
 
         def test_pickler(self):
-            basesize = support.calcobjsize('6P2n3i2n3i2P')
+            basesize = support.calcobjsize('7P2n3i2n3i2P')
             p = _pickle.Pickler(io.BytesIO())
             self.assertEqual(object.__sizeof__(p), basesize)
             MT_size = struct.calcsize('3nP0n')
@@ -500,7 +512,7 @@ def test_main():
     tests = [PyPickleTests, PyUnpicklerTests, PyPicklerTests,
              PyPersPicklerTests, PyIdPersPicklerTests,
              PyDispatchTableTests, PyChainDispatchTableTests,
-             CompatPickleTests]
+             CompatPickleTests, PyPicklerHookTests]
     if has_c_implementation:
         tests.extend([CPickleTests, CUnpicklerTests, CPicklerTests,
                       CPersPicklerTests, CIdPersPicklerTests,
@@ -508,8 +520,8 @@ def test_main():
                       PyPicklerUnpicklerObjectTests,
                       CPicklerUnpicklerObjectTests,
                       CDispatchTableTests, CChainDispatchTableTests,
-                      InMemoryPickleTests, SizeofTests
-                      ])
+                      CPicklerHookTests,
+                      InMemoryPickleTests, SizeofTests])
     support.run_unittest(*tests)
     support.run_doctest(pickle)
 

--- a/pickle5/test/test_picklebuffer.py
+++ b/pickle5/test/test_picklebuffer.py
@@ -4,13 +4,11 @@ Pickling tests themselves are in pickletester.py.
 """
 
 import gc
-import sys
+from pickle5 import PickleBuffer
 import weakref
 import unittest
 
 from test import support
-
-from pickle5 import PickleBuffer
 
 
 class B(bytes):


### PR DESCRIPTION
This PR sync up with `cpython-3.8.0rc1` to support `reducer_override`. `reducer_override` is the core function to make protocol 5 faster with cloudpickle, etc

close #8 #9 

- [x] update core functions
- [x] update all tests
- [x] renew patch file
- [x] recheck clinic headers
- [x] pass all tests 