### PR TITLE
Update backport with upstream 3.8 branch (v3.8.0-57-gfe934e1d03)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,15 @@ matrix:
   include:
   - python: "3.6"
     dist: trusty
+    arch: amd64
   - python: "3.6"
+    arch: amd64
+  - python: "3.6"
+    arch: arm64
   - python: "3.7"
+    arch: amd64
+  - python: "3.7"
+    arch: arm64
 
 install:
   - python -m venv $PY_VENV

--- a/apply_diffs.sh
+++ b/apply_diffs.sh
@@ -3,7 +3,7 @@
 # Port the newest contents of the CPython "pickle5" branch and apply them
 # to this project tree.
 
-CPYTHON=../default
+CPYTHON=../38
 
 cp -f $CPYTHON/Include/picklebufobject.h pickle5/
 cp -f $CPYTHON/Objects/picklebufobject.c pickle5/

--- a/make_diffs.sh
+++ b/make_diffs.sh
@@ -6,7 +6,7 @@
 # DIFF=colordiff
 DIFF="diff -u"
 
-CPYTHON=../default
+CPYTHON=../38
 
 $DIFF $CPYTHON/Include/picklebufobject.h pickle5/
 $DIFF $CPYTHON/Objects/picklebufobject.c pickle5/

--- a/patch
+++ b/patch
@@ -1,5 +1,5 @@
---- ../default/Include/picklebufobject.h	2019-04-24 21:34:21.441820415 +0200
-+++ pickle5/picklebufobject.h	2019-04-25 01:10:27.178803585 +0200
+--- ../38/Include/picklebufobject.h	2019-11-02 16:20:20.358405065 +0100
++++ pickle5/picklebufobject.h	2019-11-02 16:30:40.749731365 +0100
 @@ -10,18 +10,18 @@
  
  #ifndef Py_LIMITED_API
@@ -23,8 +23,8 @@
  
  #endif /* !Py_LIMITED_API */
  
---- ../default/Objects/picklebufobject.c	2019-04-24 23:22:09.714808011 +0200
-+++ pickle5/picklebufobject.c	2019-04-25 01:10:27.178803585 +0200
+--- ../38/Objects/picklebufobject.c	2019-11-02 16:20:20.834410181 +0100
++++ pickle5/picklebufobject.c	2019-11-02 16:30:40.749731365 +0100
 @@ -4,6 +4,8 @@
  #include "Python.h"
  #include <stddef.h>
@@ -34,8 +34,8 @@
  typedef struct {
      PyObject_HEAD
      /* The view exported by the original object */
---- ../default/Modules/_pickle.c	2019-04-24 23:56:10.787938850 +0200
-+++ pickle5/_pickle.c	2019-04-25 01:10:27.182803635 +0200
+--- ../38/Modules/_pickle.c	2019-11-02 16:20:20.754409320 +0100
++++ pickle5/_pickle.c	2019-11-02 16:46:35.809907792 +0100
 @@ -1,11 +1,11 @@
 -/* pickle accelerator C extensor: _pickle module.
 - *
@@ -55,7 +55,7 @@
  #endif
  
  #include "Python.h"
-@@ -706,7 +706,13 @@
+@@ -709,7 +709,13 @@
  static PyTypeObject Pickler_Type;
  static PyTypeObject Unpickler_Type;
  
@@ -69,7 +69,19 @@
  
  /*************************************************************************
   A custom hashtable mapping void* to Python ints. This is used by the pickler
-@@ -7794,11 +7800,25 @@
+@@ -7020,11 +7026,6 @@
+     PyObject *global;
+     PyObject *module;
+ 
+-    if (PySys_Audit("pickle.find_class", "OO",
+-                    module_name, global_name) < 0) {
+-        return NULL;
+-    }
+-
+     /* Try to map the old names used in Python 2.x to the new ones used in
+        Python 3.x.  We do this only with old pickle protocols and when the
+        user has not disabled the feature. */
+@@ -7877,11 +7878,25 @@
      return NULL;
  }
  
@@ -95,7 +107,7 @@
      {NULL, NULL} /* sentinel */
  };
  
-@@ -7882,6 +7902,8 @@
+@@ -7965,6 +7980,8 @@
      Py_INCREF(&Unpickler_Type);
      if (PyModule_AddObject(m, "Unpickler", (PyObject *)&Unpickler_Type) < 0)
          return NULL;
@@ -104,31 +116,18 @@
      Py_INCREF(&PyPickleBuffer_Type);
      if (PyModule_AddObject(m, "PickleBuffer",
                             (PyObject *)&PyPickleBuffer_Type) < 0)
---- ../default/Lib/pickle.py	2019-04-24 23:48:48.962087635 +0200
-+++ pickle5/pickle.py	2019-04-25 01:10:27.182803635 +0200
-@@ -36,7 +36,7 @@
- import codecs
- import _compat_pickle
+--- ../38/Lib/pickle.py	2019-11-02 16:20:20.482406398 +0100
++++ pickle5/pickle.py	2019-11-02 16:46:54.906114687 +0100
+@@ -40,7 +40,7 @@
+            "Unpickler", "dump", "dumps", "load", "loads"]
  
--from _pickle import PickleBuffer
-+from ._pickle import PickleBuffer, _make_memoryview_readonly
- 
- __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
-            "Unpickler", "dump", "dumps", "load", "loads", "PickleBuffer"]
-@@ -546,7 +546,11 @@
-             rv = reduce(obj)
-         else:
-             # Check for a class with a custom metaclass; treat as regular class
--            if issubclass(t, type):
-+            try:
-+                issc = issubclass(t, type)
-+            except TypeError: # t is not a class (old Boost; see SF #502085)
-+                issc = False
-+            if issc:
-                 self.save_global(obj)
-                 return
- 
-@@ -1364,7 +1368,9 @@
+ try:
+-    from _pickle import PickleBuffer
++    from ._pickle import PickleBuffer, _make_memoryview_readonly
+     __all__.append("PickleBuffer")
+     _HAVE_PICKLE_BUFFER = True
+ except ImportError:
+@@ -1405,7 +1405,9 @@
          buf = self.stack[-1]
          with memoryview(buf) as m:
              if not m.readonly:
@@ -139,7 +138,15 @@
      dispatch[READONLY_BUFFER[0]] = load_readonly_buffer
  
      def load_short_binstring(self):
-@@ -1717,7 +1723,7 @@
+@@ -1568,7 +1570,6 @@
+ 
+     def find_class(self, module, name):
+         # Subclasses may override this.
+-        sys.audit('pickle.find_class', module, name)
+         if self.proto < 3 and self.fix_imports:
+             if (module, name) in _compat_pickle.NAME_MAPPING:
+                 module, name = _compat_pickle.NAME_MAPPING[(module, name)]
+@@ -1759,7 +1760,7 @@
  
  # Use the faster _pickle if possible
  try:
@@ -148,8 +155,8 @@
          PickleError,
          PicklingError,
          UnpicklingError,
---- ../default/Lib/pickletools.py	2019-04-24 21:34:21.505821080 +0200
-+++ pickle5/pickletools.py	2019-04-25 01:10:27.182803635 +0200
+--- ../38/Lib/pickletools.py	2019-11-02 16:20:20.486406441 +0100
++++ pickle5/pickletools.py	2019-11-02 16:30:40.753731415 +0100
 @@ -12,10 +12,11 @@
  
  import codecs
@@ -163,18 +170,18 @@
  __all__ = ['dis', 'genops', 'optimize']
  
  bytes_types = pickle.bytes_types
---- ../default/Lib/test/pickletester.py	2019-04-25 01:09:30.430092000 +0200
-+++ pickle5/test/pickletester.py	2019-04-25 01:10:27.182803635 +0200
-@@ -4,8 +4,6 @@
- import io
+--- ../38/Lib/test/pickletester.py	2019-11-02 16:20:20.538407000 +0100
++++ pickle5/test/pickletester.py	2019-11-02 16:42:03.558511125 +0100
+@@ -5,8 +5,6 @@
  import functools
  import os
+ import math
 -import pickle
 -import pickletools
  import shutil
  import struct
  import sys
-@@ -31,7 +29,8 @@
+@@ -32,7 +30,8 @@
      _2G, _4G, bigmemtest, reap_threads, forget,
      )
  
@@ -184,7 +191,7 @@
  
  requires_32b = unittest.skipUnless(sys.maxsize < 2**32,
                                     "test is only meaningful on 32-bit builds")
-@@ -1461,12 +1460,11 @@
+@@ -1445,12 +1444,11 @@
      # of 1.
      def dont_test_disassembly(self):
          from io import StringIO
@@ -198,8 +205,24 @@
              got = filelike.getvalue()
              self.assertEqual(expected, got)
  
---- ../default/Lib/test/test_pickle.py	2019-04-24 23:20:31.049670452 +0200
-+++ pickle5/test/test_pickle.py	2019-04-25 01:10:27.182803635 +0200
+@@ -2328,7 +2326,6 @@
+         elif frameless_start is not None:
+             self.assertLess(pos - frameless_start, self.FRAME_SIZE_MIN)
+ 
+-    @support.skip_if_pgo_task
+     def test_framing_many_objects(self):
+         obj = list(range(10**5))
+         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
+@@ -2418,7 +2415,6 @@
+                                 count_opcode(pickle.FRAME, pickled))
+                 self.assertEqual(obj, self.loads(some_frames_pickle))
+ 
+-    @support.skip_if_pgo_task
+     def test_framed_write_sizes_with_delayed_writer(self):
+         class ChunkAccumulator:
+             """Accumulate pickler output in a list of raw chunks."""
+--- ../38/Lib/test/test_pickle.py	2019-11-02 16:20:20.602407687 +0100
++++ pickle5/test/test_pickle.py	2019-11-02 16:37:43.523126691 +0100
 @@ -1,7 +1,6 @@
  from _compat_pickle import (IMPORT_MAPPING, REVERSE_IMPORT_MAPPING,
                              NAME_MAPPING, REVERSE_NAME_MAPPING)
@@ -208,10 +231,11 @@
  import io
  import collections
  import struct
-@@ -11,17 +10,18 @@
+@@ -11,19 +10,20 @@
  import unittest
  from test import support
  
+-from test.pickletester import AbstractHookTests
 -from test.pickletester import AbstractUnpickleTests
 -from test.pickletester import AbstractPickleTests
 -from test.pickletester import AbstractPickleModuleTests
@@ -219,7 +243,9 @@
 -from test.pickletester import AbstractIdentityPersistentPicklerTests
 -from test.pickletester import AbstractPicklerUnpicklerObjectTests
 -from test.pickletester import AbstractDispatchTableTests
+-from test.pickletester import AbstractCustomPicklerClass
 -from test.pickletester import BigmemPickleTests
++from .pickletester import AbstractHookTests
 +from .pickletester import AbstractUnpickleTests
 +from .pickletester import AbstractPickleTests
 +from .pickletester import AbstractPickleModuleTests
@@ -227,6 +253,7 @@
 +from .pickletester import AbstractIdentityPersistentPicklerTests
 +from .pickletester import AbstractPicklerUnpicklerObjectTests
 +from .pickletester import AbstractDispatchTableTests
++from .pickletester import AbstractCustomPicklerClass
 +from .pickletester import BigmemPickleTests
  
 +import pickle5 as pickle
@@ -236,7 +263,7 @@
      has_c_implementation = True
  except ImportError:
      has_c_implementation = False
-@@ -205,7 +205,7 @@
+@@ -212,7 +212,7 @@
  
  if has_c_implementation:
      class CPickleTests(AbstractPickleModuleTests):
@@ -245,24 +272,13 @@
  
      class CUnpicklerTests(PyUnpicklerTests):
          unpickler = _pickle.Unpickler
-@@ -508,7 +508,8 @@
-                       PyPicklerUnpicklerObjectTests,
-                       CPicklerUnpicklerObjectTests,
-                       CDispatchTableTests, CChainDispatchTableTests,
--                      InMemoryPickleTests, SizeofTests])
-+                      InMemoryPickleTests, SizeofTests
-+                      ])
-     support.run_unittest(*tests)
-     support.run_doctest(pickle)
- 
---- ../default/Lib/test/test_picklebuffer.py	2019-04-25 01:11:35.679661336 +0200
-+++ pickle5/test/test_picklebuffer.py	2019-04-25 01:11:42.103741713 +0200
-@@ -4,13 +4,14 @@
+--- ../38/Lib/test/test_picklebuffer.py	2019-11-02 16:20:20.602407687 +0100
++++ pickle5/test/test_picklebuffer.py	2019-11-02 16:38:22.283628888 +0100
+@@ -4,12 +4,13 @@
  """
  
  import gc
 -from pickle import PickleBuffer
- import sys
  import weakref
  import unittest
  

--- a/pickle5/clinic/_pickle-3.6.c.h
+++ b/pickle5/clinic/_pickle-3.6.c.h
@@ -85,9 +85,16 @@ PyDoc_STRVAR(_pickle_Pickler___init____doc__,
 "to map the new Python 3 names to the old module names used in Python\n"
 "2, so that the pickle data stream is readable with Python 2.\n"
 "\n"
-"If *buffer_callback* is None (the default), buffer views are serialized\n"
-"into *file* as part of the pickle stream.  It is an error if\n"
-"*buffer_callback* is not None and *protocol* is None or smaller than 5.");
+"If *buffer_callback* is None (the default), buffer views are\n"
+"serialized into *file* as part of the pickle stream.\n"
+"\n"
+"If *buffer_callback* is not None, then it can be called any number\n"
+"of times with a buffer view.  If the callback returns a false value\n"
+"(such as None), the given buffer is out-of-band; otherwise the\n"
+"buffer is serialized in-band, i.e. inside the pickle stream.\n"
+"\n"
+"It is an error if *buffer_callback* is not None and *protocol*\n"
+"is None or smaller than 5.");
 
 static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
@@ -101,9 +108,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     static const char * const _keywords[] = {"file", "protocol", "fix_imports", "buffer_callback", NULL};
     static _PyArg_Parser _parser = {"O|OpO:Pickler", _keywords, 0};
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
         &file, &protocol, &fix_imports, &buffer_callback)) {
@@ -260,7 +267,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=None)\n"
+"          buffers=())\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -413,9 +420,9 @@ _pickle_dump(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     static _PyArg_Parser _parser = {"OO|O$pO:dump", _keywords, 0};
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
         &obj, &file, &protocol, &fix_imports, &buffer_callback)) {
@@ -465,9 +472,9 @@ _pickle_dumps(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     static const char * const _keywords[] = {"obj", "protocol", "fix_imports", "buffer_callback", NULL};
     static _PyArg_Parser _parser = {"O|O$pO:dumps", _keywords, 0};
     PyObject *obj;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseStack(args, nargs, kwnames, &_parser,
         &obj, &protocol, &fix_imports, &buffer_callback)) {
@@ -481,7 +488,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=None)\n"
+"     errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -540,7 +547,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=None)\n"
+"      errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"
@@ -587,4 +594,4 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3c1f5c0f341379d8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6e2b89d75a060f77 input=a9049054013a1b77]*/

--- a/pickle5/clinic/_pickle-3.7.c.h
+++ b/pickle5/clinic/_pickle-3.7.c.h
@@ -85,9 +85,16 @@ PyDoc_STRVAR(_pickle_Pickler___init____doc__,
 "to map the new Python 3 names to the old module names used in Python\n"
 "2, so that the pickle data stream is readable with Python 2.\n"
 "\n"
-"If *buffer_callback* is None (the default), buffer views are serialized\n"
-"into *file* as part of the pickle stream.  It is an error if\n"
-"*buffer_callback* is not None and *protocol* is None or smaller than 5.");
+"If *buffer_callback* is None (the default), buffer views are\n"
+"serialized into *file* as part of the pickle stream.\n"
+"\n"
+"If *buffer_callback* is not None, then it can be called any number\n"
+"of times with a buffer view.  If the callback returns a false value\n"
+"(such as None), the given buffer is out-of-band; otherwise the\n"
+"buffer is serialized in-band, i.e. inside the pickle stream.\n"
+"\n"
+"It is an error if *buffer_callback* is not None and *protocol*\n"
+"is None or smaller than 5.");
 
 static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
@@ -101,9 +108,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     static const char * const _keywords[] = {"file", "protocol", "fix_imports", "buffer_callback", NULL};
     static _PyArg_Parser _parser = {"O|OpO:Pickler", _keywords, 0};
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
         &file, &protocol, &fix_imports, &buffer_callback)) {
@@ -260,7 +267,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=None)\n"
+"          buffers=())\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -413,9 +420,9 @@ _pickle_dump(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     static _PyArg_Parser _parser = {"OO|O$pO:dump", _keywords, 0};
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &file, &protocol, &fix_imports, &buffer_callback)) {
@@ -465,9 +472,9 @@ _pickle_dumps(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     static const char * const _keywords[] = {"obj", "protocol", "fix_imports", "buffer_callback", NULL};
     static _PyArg_Parser _parser = {"O|O$pO:dumps", _keywords, 0};
     PyObject *obj;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &obj, &protocol, &fix_imports, &buffer_callback)) {
@@ -481,7 +488,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=None)\n"
+"     errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -540,7 +547,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=None)\n"
+"      errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"
@@ -587,4 +594,4 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d62b06f0ac75582c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dd0b345c808a6f48 input=a9049054013a1b77]*/

--- a/pickle5/clinic/_pickle.c.h
+++ b/pickle5/clinic/_pickle.c.h
@@ -85,9 +85,16 @@ PyDoc_STRVAR(_pickle_Pickler___init____doc__,
 "to map the new Python 3 names to the old module names used in Python\n"
 "2, so that the pickle data stream is readable with Python 2.\n"
 "\n"
-"If *buffer_callback* is None (the default), buffer views are serialized\n"
-"into *file* as part of the pickle stream.  It is an error if\n"
-"*buffer_callback* is not None and *protocol* is None or smaller than 5.");
+"If *buffer_callback* is None (the default), buffer views are\n"
+"serialized into *file* as part of the pickle stream.\n"
+"\n"
+"If *buffer_callback* is not None, then it can be called any number\n"
+"of times with a buffer view.  If the callback returns a false value\n"
+"(such as None), the given buffer is out-of-band; otherwise the\n"
+"buffer is serialized in-band, i.e. inside the pickle stream.\n"
+"\n"
+"It is an error if *buffer_callback* is not None and *protocol*\n"
+"is None or smaller than 5.");
 
 static int
 _pickle_Pickler___init___impl(PicklerObject *self, PyObject *file,
@@ -105,9 +112,9 @@ _pickle_Pickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_ssize_t nargs = PyTuple_GET_SIZE(args);
     Py_ssize_t noptargs = nargs + (kwargs ? PyDict_GET_SIZE(kwargs) : 0) - 1;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     fastargs = _PyArg_UnpackKeywords(_PyTuple_CAST(args)->ob_item, nargs, kwargs, NULL, &_parser, 1, 4, 0, argsbuf);
     if (!fastargs) {
@@ -285,7 +292,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_Unpickler___init____doc__,
 "Unpickler(file, *, fix_imports=True, encoding=\'ASCII\', errors=\'strict\',\n"
-"          buffers=None)\n"
+"          buffers=())\n"
 "--\n"
 "\n"
 "This takes a binary file for reading a pickle data stream.\n"
@@ -349,7 +356,7 @@ _pickle_Unpickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     if (fastargs[2]) {
         if (!PyUnicode_Check(fastargs[2])) {
-            _PyArg_BadArgument("Unpickler", 3, "str", fastargs[2]);
+            _PyArg_BadArgument("Unpickler", "argument 'encoding'", "str", fastargs[2]);
             goto exit;
         }
         Py_ssize_t encoding_length;
@@ -367,7 +374,7 @@ _pickle_Unpickler___init__(PyObject *self, PyObject *args, PyObject *kwargs)
     }
     if (fastargs[3]) {
         if (!PyUnicode_Check(fastargs[3])) {
-            _PyArg_BadArgument("Unpickler", 4, "str", fastargs[3]);
+            _PyArg_BadArgument("Unpickler", "argument 'errors'", "str", fastargs[3]);
             goto exit;
         }
         Py_ssize_t errors_length;
@@ -495,9 +502,9 @@ _pickle_dump(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 2;
     PyObject *obj;
     PyObject *file;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 2, 3, 0, argsbuf);
     if (!args) {
@@ -575,9 +582,9 @@ _pickle_dumps(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     PyObject *argsbuf[4];
     Py_ssize_t noptargs = nargs + (kwnames ? PyTuple_GET_SIZE(kwnames) : 0) - 1;
     PyObject *obj;
-    PyObject *protocol = NULL;
+    PyObject *protocol = Py_None;
     int fix_imports = 1;
-    PyObject *buffer_callback = NULL;
+    PyObject *buffer_callback = Py_None;
 
     args = _PyArg_UnpackKeywords(args, nargs, NULL, kwnames, &_parser, 1, 2, 0, argsbuf);
     if (!args) {
@@ -616,7 +623,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_load__doc__,
 "load($module, /, file, *, fix_imports=True, encoding=\'ASCII\',\n"
-"     errors=\'strict\', buffers=None)\n"
+"     errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the pickle data stored in a file.\n"
@@ -684,7 +691,7 @@ _pickle_load(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     }
     if (args[2]) {
         if (!PyUnicode_Check(args[2])) {
-            _PyArg_BadArgument("load", 3, "str", args[2]);
+            _PyArg_BadArgument("load", "argument 'encoding'", "str", args[2]);
             goto exit;
         }
         Py_ssize_t encoding_length;
@@ -702,7 +709,7 @@ _pickle_load(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
     }
     if (args[3]) {
         if (!PyUnicode_Check(args[3])) {
-            _PyArg_BadArgument("load", 4, "str", args[3]);
+            _PyArg_BadArgument("load", "argument 'errors'", "str", args[3]);
             goto exit;
         }
         Py_ssize_t errors_length;
@@ -728,7 +735,7 @@ exit:
 
 PyDoc_STRVAR(_pickle_loads__doc__,
 "loads($module, /, data, *, fix_imports=True, encoding=\'ASCII\',\n"
-"      errors=\'strict\', buffers=None)\n"
+"      errors=\'strict\', buffers=())\n"
 "--\n"
 "\n"
 "Read and return an object from the given pickle data.\n"
@@ -787,7 +794,7 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     }
     if (args[2]) {
         if (!PyUnicode_Check(args[2])) {
-            _PyArg_BadArgument("loads", 3, "str", args[2]);
+            _PyArg_BadArgument("loads", "argument 'encoding'", "str", args[2]);
             goto exit;
         }
         Py_ssize_t encoding_length;
@@ -805,7 +812,7 @@ _pickle_loads(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObjec
     }
     if (args[3]) {
         if (!PyUnicode_Check(args[3])) {
-            _PyArg_BadArgument("loads", 4, "str", args[3]);
+            _PyArg_BadArgument("loads", "argument 'errors'", "str", args[3]);
             goto exit;
         }
         Py_ssize_t errors_length;
@@ -828,4 +835,4 @@ skip_optional_kwonly:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2fafc02c65351b51 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=de075ec48d4ee0e1 input=a9049054013a1b77]*/

--- a/pickle5/compat.h
+++ b/pickle5/compat.h
@@ -4,7 +4,10 @@
 
 #if PY_VERSION_HEX < 0x03080000
 
-/* Convenience function to get a builtin from its name */
+/* Convenience function to get a builtin from its name.
+ * Note this was backported at some point to 3.6.x and 3.7.x,
+ * so it's possible to get a compilation warning.
+ */
 PyObject *
 _PyEval_GetBuiltinId(_Py_Identifier *name)
 {
@@ -89,30 +92,6 @@ _PyObject_LookupAttrId(PyObject *v, _Py_Identifier *name, PyObject **result)
         return -1;
     }
     return  _PyObject_LookupAttr(v, oname, result);
-}
-
-static PyObject *
-PyImport_GetModule(PyObject *name)
-{
-    PyObject *m;
-    PyObject *modules = PyImport_GetModuleDict();
-    if (modules == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
-        return NULL;
-    }
-    Py_INCREF(modules);
-    if (PyDict_CheckExact(modules)) {
-        m = PyDict_GetItemWithError(modules, name);  /* borrowed */
-        Py_XINCREF(m);
-    }
-    else {
-        m = PyObject_GetItem(modules, name);
-        if (m == NULL && PyErr_ExceptionMatches(PyExc_KeyError)) {
-            PyErr_Clear();
-        }
-    }
-    Py_DECREF(modules);
-    return m;
 }
 
 #endif

--- a/pickle5/pickle.py
+++ b/pickle5/pickle.py
@@ -36,10 +36,16 @@ import io
 import codecs
 import _compat_pickle
 
-from ._pickle import PickleBuffer, _make_memoryview_readonly
-
 __all__ = ["PickleError", "PicklingError", "UnpicklingError", "Pickler",
-           "Unpickler", "dump", "dumps", "load", "loads", "PickleBuffer"]
+           "Unpickler", "dump", "dumps", "load", "loads"]
+
+try:
+    from ._pickle import PickleBuffer, _make_memoryview_readonly
+    __all__.append("PickleBuffer")
+    _HAVE_PICKLE_BUFFER = True
+except ImportError:
+    _HAVE_PICKLE_BUFFER = False
+
 
 # Shortcut for use in isinstance testing
 bytes_types = (bytes, bytearray)
@@ -423,9 +429,15 @@ class _Pickler:
         with Python 2.
 
         If *buffer_callback* is None (the default), buffer views are
-        serialized into *file* as part of the pickle stream.  It is
-        an error if *buffer_callback* is not None and *protocol* is
-        None or smaller than 5.
+        serialized into *file* as part of the pickle stream.
+
+        If *buffer_callback* is not None, then it can be called any number
+        of times with a buffer view.  If the callback returns a false value
+        (such as None), the given buffer is out-of-band; otherwise the
+        buffer is serialized in-band, i.e. inside the pickle stream.
+
+        It is an error if *buffer_callback* is not None and *protocol*
+        is None or smaller than 5.
         """
         if protocol is None:
             protocol = DEFAULT_PROTOCOL
@@ -533,38 +545,42 @@ class _Pickler:
             self.write(self.get(x[0]))
             return
 
-        # Check the type dispatch table
-        t = type(obj)
-        f = self.dispatch.get(t)
-        if f is not None:
-            f(self, obj) # Call unbound method with explicit self
-            return
-
-        # Check private dispatch table if any, or else copyreg.dispatch_table
-        reduce = getattr(self, 'dispatch_table', dispatch_table).get(t)
+        rv = NotImplemented
+        reduce = getattr(self, "reducer_override", None)
         if reduce is not None:
             rv = reduce(obj)
-        else:
-            # Check for a class with a custom metaclass; treat as regular class
-            try:
-                issc = issubclass(t, type)
-            except TypeError: # t is not a class (old Boost; see SF #502085)
-                issc = False
-            if issc:
-                self.save_global(obj)
+
+        if rv is NotImplemented:
+            # Check the type dispatch table
+            t = type(obj)
+            f = self.dispatch.get(t)
+            if f is not None:
+                f(self, obj)  # Call unbound method with explicit self
                 return
 
-            # Check for a __reduce_ex__ method, fall back to __reduce__
-            reduce = getattr(obj, "__reduce_ex__", None)
+            # Check private dispatch table if any, or else
+            # copyreg.dispatch_table
+            reduce = getattr(self, 'dispatch_table', dispatch_table).get(t)
             if reduce is not None:
-                rv = reduce(self.proto)
+                rv = reduce(obj)
             else:
-                reduce = getattr(obj, "__reduce__", None)
+                # Check for a class with a custom metaclass; treat as regular
+                # class
+                if issubclass(t, type):
+                    self.save_global(obj)
+                    return
+
+                # Check for a __reduce_ex__ method, fall back to __reduce__
+                reduce = getattr(obj, "__reduce_ex__", None)
                 if reduce is not None:
-                    rv = reduce()
+                    rv = reduce(self.proto)
                 else:
-                    raise PicklingError("Can't pickle %r object: %r" %
-                                        (t.__name__, obj))
+                    reduce = getattr(obj, "__reduce__", None)
+                    if reduce is not None:
+                        rv = reduce()
+                    else:
+                        raise PicklingError("Can't pickle %r object: %r" %
+                                            (t.__name__, obj))
 
         # Check for string returned by reduce(), meaning "save as global"
         if isinstance(rv, str):
@@ -577,9 +593,9 @@ class _Pickler:
 
         # Assert that it returned an appropriately sized tuple
         l = len(rv)
-        if not (2 <= l <= 5):
+        if not (2 <= l <= 6):
             raise PicklingError("Tuple returned by %s must have "
-                                "two to five elements" % reduce)
+                                "two to six elements" % reduce)
 
         # Save the reduce() output and finally memoize the object
         self.save_reduce(obj=obj, *rv)
@@ -601,7 +617,7 @@ class _Pickler:
                     "persistent IDs in protocol 0 must be ASCII strings")
 
     def save_reduce(self, func, args, state=None, listitems=None,
-                    dictitems=None, obj=None):
+                    dictitems=None, state_setter=None, obj=None):
         # This API is called by some subclasses
 
         if not isinstance(args, tuple):
@@ -695,8 +711,25 @@ class _Pickler:
             self._batch_setitems(dictitems)
 
         if state is not None:
-            save(state)
-            write(BUILD)
+            if state_setter is None:
+                save(state)
+                write(BUILD)
+            else:
+                # If a state_setter is specified, call it instead of load_build
+                # to update obj's with its previous state.
+                # First, push state_setter and its tuple of expected arguments
+                # (obj, state) onto the stack.
+                save(state_setter)
+                save(obj)  # simple BINGET opcode as obj is already memoized.
+                save(state)
+                write(TUPLE2)
+                # Trigger a state_setter(obj, state) function call.
+                write(REDUCE)
+                # The purpose of state_setter is to carry-out an
+                # inplace modification of obj. We do not care about what the
+                # method might return, so its output is eventually removed from
+                # the stack.
+                write(POP)
 
     # Methods below this point are dispatched through the dispatch table
 
@@ -785,31 +818,32 @@ class _Pickler:
             self.write(BYTEARRAY8 + pack("<Q", n) + obj)
     dispatch[bytearray] = save_bytearray
 
-    def save_picklebuffer(self, obj):
-        if self.proto < 5:
-            raise PicklingError("PickleBuffer can only pickled with "
-                                "protocol >= 5")
-        with obj.raw() as m:
-            if not m.contiguous:
-                raise PicklingError("PickleBuffer can not be pickled when "
-                                    "pointing to a non-contiguous buffer")
-            in_band = True
-            if self._buffer_callback is not None:
-                in_band = bool(self._buffer_callback(obj))
-            if in_band:
-                # Write data in-band
-                # XXX we could avoid a copy here
-                if m.readonly:
-                    self.save_bytes(m.tobytes())
+    if _HAVE_PICKLE_BUFFER:
+        def save_picklebuffer(self, obj):
+            if self.proto < 5:
+                raise PicklingError("PickleBuffer can only pickled with "
+                                    "protocol >= 5")
+            with obj.raw() as m:
+                if not m.contiguous:
+                    raise PicklingError("PickleBuffer can not be pickled when "
+                                        "pointing to a non-contiguous buffer")
+                in_band = True
+                if self._buffer_callback is not None:
+                    in_band = bool(self._buffer_callback(obj))
+                if in_band:
+                    # Write data in-band
+                    # XXX The C implementation avoids a copy here
+                    if m.readonly:
+                        self.save_bytes(m.tobytes())
+                    else:
+                        self.save_bytearray(m.tobytes())
                 else:
-                    self.save_bytearray(m.tobytes())
-            else:
-                # Write data out-of-band
-                self.write(NEXT_BUFFER)
-                if m.readonly:
-                    self.write(READONLY_BUFFER)
+                    # Write data out-of-band
+                    self.write(NEXT_BUFFER)
+                    if m.readonly:
+                        self.write(READONLY_BUFFER)
 
-    dispatch[PickleBuffer] = save_picklebuffer
+        dispatch[PickleBuffer] = save_picklebuffer
 
     def save_str(self, obj):
         if self.bin:
@@ -825,7 +859,10 @@ class _Pickler:
                 self.write(BINUNICODE + pack("<I", n) + encoded)
         else:
             obj = obj.replace("\\", "\\u005c")
+            obj = obj.replace("\0", "\\u0000")
             obj = obj.replace("\n", "\\u000a")
+            obj = obj.replace("\r", "\\u000d")
+            obj = obj.replace("\x1a", "\\u001a")  # EOF on DOS
             self.write(UNICODE + obj.encode('raw-unicode-escape') +
                        b'\n')
         self.memoize(obj)

--- a/pickle5/picklebufobject.c
+++ b/pickle5/picklebufobject.c
@@ -208,7 +208,7 @@ static PyMethodDef picklebuf_methods[] = {
 PyTypeObject PyPickleBuffer_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "pickle.PickleBuffer",
-    .tp_doc = "Out-of-band buffer",
+    .tp_doc = "Wrapper for potentially out-of-band buffers",
     .tp_basicsize = sizeof(PyPickleBufferObject),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = picklebuf_new,

--- a/pickle5/test/pickletester.py
+++ b/pickle5/test/pickletester.py
@@ -4,6 +4,7 @@ import dbm
 import io
 import functools
 import os
+import math
 import shutil
 import struct
 import sys
@@ -69,23 +70,6 @@ class UnseekableIO(io.BytesIO):
 
     def tell(self):
         raise io.UnsupportedOperation
-
-
-class TrivialReadableIO:
-    """
-    A readable file object that doesn't support readinto().
-    """
-    def __init__(self, *args, **kwargs):
-        self._bio = io.BytesIO(*args, **kwargs)
-
-    def read(self, n):
-        return self._bio.read(n)
-
-    def readline(self, n=None):
-        return self._bio.readline(n)
-
-    def getvalue(self):
-        return self._bio.getvalue()
 
 
 # We can't very well test the extension registry without putting known stuff
@@ -2414,7 +2398,7 @@ class AbstractPickleTests(unittest.TestCase):
 
         frame_size = self.FRAME_SIZE_TARGET
         num_frames = 20
-        # Large byte objects (dict values) intermitted with small objects
+        # Large byte objects (dict values) intermittent with small objects
         # (dict keys)
         for bytes_type in (bytes, bytearray):
             obj = {i: bytes_type([i]) * frame_size for i in range(num_frames)}
@@ -2779,6 +2763,11 @@ class AbstractPickleTests(unittest.TestCase):
             with self.assertRaises(pickle.UnpicklingError):
                 self.loads(data, buffers=[])
 
+    def test_inband_accept_default_buffers_argument(self):
+        for proto in range(5, pickle.HIGHEST_PROTOCOL + 1):
+            data_pickled = self.dumps(1, proto, buffer_callback=None)
+            data = self.loads(data_pickled, buffers=None)
+
     @unittest.skipIf(np is None, "Test needs Numpy")
     def test_buffers_numpy(self):
         def check_no_copy(x, y):
@@ -3081,22 +3070,20 @@ class BadGetattr:
 class AbstractPickleModuleTests(unittest.TestCase):
 
     def test_dump_closed_file(self):
-        import os
         f = open(TESTFN, "wb")
         try:
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            os.remove(TESTFN)
+            support.unlink(TESTFN)
 
     def test_load_closed_file(self):
-        import os
         f = open(TESTFN, "wb")
         try:
             f.close()
             self.assertRaises(ValueError, self.dump, 123, f)
         finally:
-            os.remove(TESTFN)
+            support.unlink(TESTFN)
 
     def test_load_from_and_dump_to_file(self):
         stream = io.BytesIO()
@@ -3119,6 +3106,19 @@ class AbstractPickleModuleTests(unittest.TestCase):
         self.dumps(123, protocol=-1)
         self.Pickler(f, -1)
         self.Pickler(f, protocol=-1)
+
+    def test_dump_text_file(self):
+        f = open(TESTFN, "w")
+        try:
+            for proto in protocols:
+                self.assertRaises(TypeError, self.dump, 123, f, proto)
+        finally:
+            f.close()
+            support.unlink(TESTFN)
+
+    def test_incomplete_input(self):
+        s = io.BytesIO(b"X''.")
+        self.assertRaises((EOFError, struct.error, pickle.UnpicklingError), self.load, s)
 
     def test_bad_init(self):
         # Test issue3664 (pickle can segfault from a badly initialized Pickler).
@@ -3396,22 +3396,6 @@ class AbstractPicklerUnpicklerObjectTests(unittest.TestCase):
                 unpickler = self.unpickler_class(f)
                 self.assertEqual(unpickler.load(), data)
 
-    def test_unpickling_trivial_io(self):
-        # Check unpickling with an io class that doesn't have readinto()
-        sizes = [1, 16, 1000, 2**10]
-        data = [(b"x" * size, bytearray(b"x") * size) for size in sizes]
-        for proto in protocols:
-            with self.subTest(proto=proto):
-                bio = io.BytesIO()
-                pickler = self.pickler_class(bio, protocol=proto)
-                pickler.dump(data)
-                N = 5
-                f = TrivialReadableIO(bio.getvalue() * N)
-                unpickler = self.unpickler_class(f)
-                for i in range(N):
-                    self.assertEqual(unpickler.load(), data)
-                self.assertRaises(EOFError, unpickler.load)
-
 
 # Tests for dispatch_table attribute
 
@@ -3422,7 +3406,93 @@ class AAA(object):
         return str, (REDUCE_A,)
 
 class BBB(object):
-    pass
+    def __init__(self):
+        # Add an instance attribute to enable state-saving routines at pickling
+        # time.
+        self.a = "some attribute"
+
+    def __setstate__(self, state):
+        self.a = "BBB.__setstate__"
+
+
+def setstate_bbb(obj, state):
+    """Custom state setter for BBB objects
+
+    Such callable may be created by other persons than the ones who created the
+    BBB class. If passed as the state_setter item of a custom reducer, this
+    allows for custom state setting behavior of BBB objects. One can think of
+    it as the analogous of list_setitems or dict_setitems but for foreign
+    classes/functions.
+    """
+    obj.a = "custom state_setter"
+
+
+
+class AbstractCustomPicklerClass:
+    """Pickler implementing a reducing hook using reducer_override."""
+    def reducer_override(self, obj):
+        obj_name = getattr(obj, "__name__", None)
+
+        if obj_name == 'f':
+            # asking the pickler to save f as 5
+            return int, (5, )
+
+        if obj_name == 'MyClass':
+            return str, ('some str',)
+
+        elif obj_name == 'g':
+            # in this case, the callback returns an invalid result (not a 2-5
+            # tuple or a string), the pickler should raise a proper error.
+            return False
+
+        elif obj_name == 'h':
+            # Simulate a case when the reducer fails. The error should
+            # be propagated to the original ``dump`` call.
+            raise ValueError('The reducer just failed')
+
+        return NotImplemented
+
+class AbstractHookTests(unittest.TestCase):
+    def test_pickler_hook(self):
+        # test the ability of a custom, user-defined CPickler subclass to
+        # override the default reducing routines of any type using the method
+        # reducer_override
+
+        def f():
+            pass
+
+        def g():
+            pass
+
+        def h():
+            pass
+
+        class MyClass:
+            pass
+
+        for proto in range(0, pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(proto=proto):
+                bio = io.BytesIO()
+                p = self.pickler_class(bio, proto)
+
+                p.dump([f, MyClass, math.log])
+                new_f, some_str, math_log = pickle.loads(bio.getvalue())
+
+                self.assertEqual(new_f, 5)
+                self.assertEqual(some_str, 'some str')
+                # math.log does not have its usual reducer overriden, so the
+                # custom reduction callback should silently direct the pickler
+                # to the default pickling by attribute, by returning
+                # NotImplemented
+                self.assertIs(math_log, math.log)
+
+                with self.assertRaises(pickle.PicklingError):
+                    p.dump(g)
+
+                with self.assertRaisesRegex(
+                        ValueError, 'The reducer just failed'):
+                    p.dump(h)
+
 
 class AbstractDispatchTableTests(unittest.TestCase):
 
@@ -3510,6 +3580,25 @@ class AbstractDispatchTableTests(unittest.TestCase):
         self.assertIsInstance(custom_load_dump(b), BBB)
         self.assertEqual(default_load_dump(a), REDUCE_A)
         self.assertIsInstance(default_load_dump(b), BBB)
+
+        # End-to-end testing of save_reduce with the state_setter keyword
+        # argument. This is a dispatch_table test as the primary goal of
+        # state_setter is to tweak objects reduction behavior.
+        # In particular, state_setter is useful when the default __setstate__
+        # behavior is not flexible enough.
+
+        # No custom reducer for b has been registered for now, so
+        # BBB.__setstate__ should be used at unpickling time
+        self.assertEqual(default_load_dump(b).a, "BBB.__setstate__")
+
+        def reduce_bbb(obj):
+            return BBB, (), obj.__dict__, None, None, setstate_bbb
+
+        dispatch_table[BBB] = reduce_bbb
+
+        # The custom reducer reduce_bbb includes a state setter, that should
+        # have priority over BBB.__setstate__
+        self.assertEqual(custom_load_dump(b).a, "custom state_setter")
 
 
 if __name__ == "__main__":

--- a/pickle5/test/test_picklebuffer.py
+++ b/pickle5/test/test_picklebuffer.py
@@ -4,7 +4,6 @@ Pickling tests themselves are in pickletester.py.
 """
 
 import gc
-import sys
 import weakref
 import unittest
 


### PR DESCRIPTION
Includes support for Python 3.8's [`reducer_override`](https://docs.python.org/3/library/pickle.html#pickle.Pickler.reducer_override) feature.

Closes #8, #9.