### PR TITLE
Use `pickle5` module name for `PickleBuffer`

### DIFF
--- a/pickle5/picklebufobject.c
+++ b/pickle5/picklebufobject.c
@@ -207,7 +207,7 @@ static PyMethodDef picklebuf_methods[] = {
 
 PyTypeObject PyPickleBuffer_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "pickle.PickleBuffer",
+    .tp_name = "pickle5.PickleBuffer",
     .tp_doc = "Wrapper for potentially out-of-band buffers",
     .tp_basicsize = sizeof(PyPickleBufferObject),
     .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,


### PR DESCRIPTION
Fixes https://github.com/pitrou/pickle5-backport/issues/19

As `PickleBuffer` actually lives in the `pickle5` module of this backport package (as opposed to `pickle` in upstream CPython), update the module name here to reflect that. This should ensure libraries trying to locate where `PickleBuffer` identify it comes from `pickle5`.

cc @pitrou