### PR TITLE
Add `python_requires` to avoid it being installed for python 3.8/3.9.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     url="https://github.com/pitrou/pickle5-backport",
     packages=find_packages(),
     ext_modules=ext_modules,
+    python_requires='>=3.5, <3.8',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes #25.